### PR TITLE
Randomly choose which node to impact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ I'm aiming for a stable API, but that is not guaranteed until the 1.0 release. I
 #### External changes
 
 - Require `click`.
+- Includes a `--num-bugs` arg.
+- Modifies specified number of import nodes.
+- Randomly selects which relevant node to modify.
 
 #### Internal changes
 
 - CLI is built on `click`, rather than `argparse`.
+- Uses a random seed when `PY_BUGGER_RANDOM_SEED` env var is set, for testing.
 
 ### 0.1.0
 

--- a/src/py_bugger/cli.py
+++ b/src/py_bugger/cli.py
@@ -18,7 +18,14 @@ from py_bugger import cli_messages
     type=str,
     help="What code directory to target. (Be careful when using this arg!)",
 )
-def cli(exception_type, target_dir):
+@click.option(
+    "--num-bugs",
+    "-n",
+    type=int,
+    default=1,
+    help="How many bugs to introduce.",
+)
+def cli(exception_type, target_dir, num_bugs):
     """Practice debugging, by intentionally introducing bugs into an existing codebase."""
     if not exception_type:
         click.echo(cli_messages.msg_bare_call)

--- a/src/py_bugger/cli.py
+++ b/src/py_bugger/cli.py
@@ -31,4 +31,4 @@ def cli(exception_type, target_dir, num_bugs):
         click.echo(cli_messages.msg_bare_call)
         sys.exit()
 
-    py_bugger.main(exception_type, target_dir)
+    py_bugger.main(exception_type, target_dir, num_bugs)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -7,8 +7,8 @@ from pathlib import Path
 class ImportModifier(cst.CSTTransformer):
     """Modify imports in the user's project."""
 
-    def __init__(self, num_errors=1):
-        self.num_errors = num_errors
+    def __init__(self, num_bugs=1):
+        self.num_bugs = num_bugs
         self.num_introduced = 0
 
     def leave_Import(self, original_node, updated_node):
@@ -18,7 +18,7 @@ class ImportModifier(cst.CSTTransformer):
         if names:
             original_name = names[0].name.value
 
-            if self.num_introduced < self.num_errors:
+            if self.num_introduced < self.num_bugs:
                 # Remove one letter from the package name.
                 chars = list(original_name)
                 char_remove = random.choice(chars)
@@ -37,7 +37,7 @@ class ImportModifier(cst.CSTTransformer):
         return updated_node
 
 
-def main(exception_type, target_dir):
+def main(exception_type, target_dir, num_bugs):
 
     if exception_type == "ModuleNotFoundError":
         print("Introducing a ModuleNotFoundError...")
@@ -57,7 +57,7 @@ def main(exception_type, target_dir):
         tree = cst.parse_module(source)
 
         # Modify user's code.
-        modified_tree = tree.visit(ImportModifier())
+        modified_tree = tree.visit(ImportModifier(num_bugs=num_bugs))
 
         # Rewrite user's code.
         path.write_text(modified_tree.code)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -26,7 +26,6 @@ class ImportModifier(cst.CSTTransformer):
         names = updated_node.names
 
         if original_node in self.nodes_to_break:
-            print("HERE")
             original_name = names[0].name.value
 
             # Remove one letter from the package name.
@@ -44,6 +43,10 @@ class ImportModifier(cst.CSTTransformer):
 
 
 def main(exception_type, target_dir, num_bugs):
+
+    # Set a random seed when testing.
+    if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
+        random.seed(int(seed))
 
     if exception_type == "ModuleNotFoundError":
         print("Introducing a ModuleNotFoundError...")

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -7,17 +7,27 @@ from pathlib import Path
 class ImportModifier(cst.CSTTransformer):
     """Modify imports in the user's project."""
 
+    def __init__(self, num_errors=1):
+        self.num_errors = num_errors
+        self.num_introduced = 0
+
     def leave_Import(self, original_node, updated_node):
         """Modify a direct `import <package>` statement."""
         names = updated_node.names
+
         if names:
             original_name = names[0].name.value
 
-            # Remove one letter from the package name.
-            chars = list(original_name)
-            char_remove = random.choice(chars)
-            chars.remove(char_remove)
-            new_name = "".join(chars)
+            if self.num_introduced < self.num_errors:
+                # Remove one letter from the package name.
+                chars = list(original_name)
+                char_remove = random.choice(chars)
+                chars.remove(char_remove)
+                new_name = "".join(chars)
+
+                self.num_introduced += 1
+            else:
+                new_name = original_name
 
             # Modify the node name.
             new_names = [cst.ImportAlias(name=cst.Name(new_name))]

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -1,10 +1,16 @@
 from pathlib import Path
 import sys
+import os
 
 import pytest
 
 
 # --- Fixtures ---
+
+@pytest.fixture(autouse=True, scope="session")
+def set_random_seed_env():
+    """Make random selections repeatable."""
+    os.environ["PY_BUGGER_RANDOM_SEED"] = "10"
 
 
 @pytest.fixture(scope="session")
@@ -23,6 +29,7 @@ def e2e_config():
         path_sample_scripts = path_sample_code / "sample_scripts"
         path_name_picker = path_sample_scripts / "name_picker.py"
         path_system_info = path_sample_scripts / "system_info_script.py"
+        path_ten_imports = path_sample_scripts / "ten_imports.py"
 
         # Python executable
         if sys.platform == "win32":

--- a/tests/e2e_tests/reference_files/help.txt
+++ b/tests/e2e_tests/reference_files/help.txt
@@ -7,4 +7,5 @@ Options:
   -e, --exception-type TEXT  What kind of exception to induce.
   --target-dir TEXT          What code directory to target. (Be careful when
                              using this arg!)
+  -n, --num-bugs INTEGER     How many bugs to introduce.
   --help                     Show this message and exit.

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -103,8 +103,8 @@ def test_default_one_error(tmp_path_factory, e2e_config):
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
-    assert 'system_info_script.py", line 3, in <module>' in stderr
-    assert "ModuleNotFoundError: No module named" in stderr
+    assert 'system_info_script.py", line 4, in <module>' in stderr
+    assert "ModuleNotFoundError: No module named 'o'" in stderr
 
     # Read modified file; should have changed only one import statement.
     modified_source = path_dst.read_text()
@@ -133,9 +133,39 @@ def test_two_bugs(tmp_path_factory, e2e_config):
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
     assert 'system_info_script.py", line 3, in <module>' in stderr
-    assert "ModuleNotFoundError: No module named" in stderr
+    assert "ModuleNotFoundError: No module named 'ys'" in stderr
 
     # Read modified file; should have changed both import statements.
     modified_source = path_dst.read_text()
     assert "import sys"  not in modified_source
     assert "import os" not in modified_source
+
+def test_random_import_affected(tmp_path_factory, e2e_config):
+    """py-bugger --exception-type ModuleNotFoundError
+
+    Test that a random import statement is modified.
+    """
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_dst = tmp_path / e2e_config.path_ten_imports.name
+    shutil.copyfile(e2e_config.path_ten_imports, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()}"
+    print(cmd)
+    cmd_parts = shlex.split(cmd)
+    subprocess.run(cmd_parts)
+
+    # Run file, should raise ModuleNotFoundError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert "Traceback (most recent call last)" in stderr
+    assert 'ten_imports.py", line 6, in <module>' in stderr
+    assert "ModuleNotFoundError: No module named 'clendar'" in stderr
+
+    # Read modified file; should have changed both import statements.
+    modified_source = path_dst.read_text()
+    assert "import clendar" in modified_source

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -109,3 +109,33 @@ def test_default_one_error(tmp_path_factory, e2e_config):
     # Read modified file; should have changed only one import statement.
     modified_source = path_dst.read_text()
     assert "import sys" in modified_source or "import os" in modified_source
+
+def test_two_bugs(tmp_path_factory, e2e_config):
+    """py-bugger --exception-type ModuleNotFoundError --num-bugs 2
+
+    Test that both import statements are modified.
+    """
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_dst = tmp_path / e2e_config.path_system_info.name
+    shutil.copyfile(e2e_config.path_system_info, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --exception-type ModuleNotFoundError --num-bugs 2 --target-dir {tmp_path.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    subprocess.run(cmd_parts)
+
+    # Run file, should raise ModuleNotFoundError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert "Traceback (most recent call last)" in stderr
+    assert 'system_info_script.py", line 3, in <module>' in stderr
+    assert "ModuleNotFoundError: No module named" in stderr
+
+    # Read modified file; should have changed both import statements.
+    modified_source = path_dst.read_text()
+    assert "import sys"  not in modified_source
+    assert "import os" not in modified_source

--- a/tests/sample_code/sample_scripts/ten_imports.py
+++ b/tests/sample_code/sample_scripts/ten_imports.py
@@ -1,0 +1,10 @@
+import os
+import sys
+import re
+import random
+import difflib
+import calendar
+import zoneinfo
+import array
+import pprint
+import enum


### PR DESCRIPTION
When a `ModuleNotFoundError` is requested, choose which import statement to modify randomly. Don't just modify the first one, or all of them.