### PR TITLE
Walk filetree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ I'm aiming for a stable API, but that is not guaranteed until the 1.0 release. I
 
 - CLI is built on `click`, rather than `argparse`.
 - Uses a random seed when `PY_BUGGER_RANDOM_SEED` env var is set, for testing.
+- Utils dir, with initial `file_utils.py` module.
+- Finds all .py files we can consider changing.
+    - If using Git, returns all tracked .py files not related to testing.
+    - If not using Git, returns all .py files not in venv, dist, build, or tests.
 
 ### 0.1.0
 

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -55,14 +55,12 @@ def main(exception_type, target_dir, num_bugs):
 
         # Get the first .py file in the project's root dir.
         if target_dir:
-            path_project = Path(target_dir)
-            assert path_project.exists()
+            target_dir = Path(target_dir)
+            assert target_dir.exists()
         else:
-            path_project = Path(os.getcwd())
+            target_dir = Path(os.getcwd())
 
-        # py_files = path_project.glob("*.py")
-        # path = next(py_files)
-        py_files = file_utils.get_py_files(path_project)
+        py_files = file_utils.get_py_files(target_dir)
         path = py_files[0]
 
         # Read user's code.
@@ -72,7 +70,6 @@ def main(exception_type, target_dir, num_bugs):
         # Collect all import nodes.
         import_collector = ImportCollector()
         tree.visit(import_collector)
-        # breakpoint()
 
         nodes_to_break = random.choices(import_collector.import_nodes, k=num_bugs)
 

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -3,6 +3,8 @@ import os
 import random
 from pathlib import Path
 
+from py_bugger.utils import file_utils
+
 
 class ImportCollector(cst.CSTVisitor):
     """Visit all import nodes, without modifying."""
@@ -58,8 +60,10 @@ def main(exception_type, target_dir, num_bugs):
         else:
             path_project = Path(os.getcwd())
 
-        py_files = path_project.glob("*.py")
-        path = next(py_files)
+        # py_files = path_project.glob("*.py")
+        # path = next(py_files)
+        py_files = file_utils.get_py_files(path_project)
+        path = py_files[0]
 
         # Read user's code.
         source = path.read_text()

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -29,6 +29,7 @@ def _get_py_files_git(target_dir):
     # Convert to path objects. Filter out any test-related files.
     py_files = [Path(f) for f in py_files]
     py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
+    py_files = [pf for pf in py_files if pf.name != "conftest.py"]
 
     return py_files
 
@@ -41,5 +42,6 @@ def _get_py_files_non_git(target_dir):
         pf for pf in py_files
         if not any(ex_dir in pf.as_posix() for ex_dir in exclude_dirs)
     ]
+    py_files = [pf for pf in py_files if pf.name != "conftest.py"]
 
     return py_files

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -25,9 +25,11 @@ def get_py_files(target_dir):
     # Project does not seem to be using Git. Return all .py files not in .venv, and
     # outside of any tests/ dir, build/ dir, or dist/ dir.
     py_files = target_dir.rglob("*.py")
-    py_files = [pf for pf in py_files if ".venv/" not in pf.as_posix()]
-    py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
-    py_files = [pf for pf in py_files if "build/" not in pf.as_posix()]
-    py_files = [pf for pf in py_files if "dist/" not in pf.as_posix()]
+
+    exclude_dirs = [".venv/", "tests", "build/", "dist"]
+    py_files = [
+        pf for pf in py_files
+        if not any(ex_dir in pf.as_posix() for ex_dir in exclude_dirs)
+    ]
 
     return py_files

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -1,7 +1,38 @@
 """Utilities for working with the target project's files and directories."""
 
+import subprocess
+import shlex
+from pathlib import Path
+import sys
+
+
 def get_py_files(target_dir):
     """Get all the .py files we can consider modifying when introducing bugs."""
-    py_files = target_dir.glob("*.py")
-    path = next(py_files)
-    return [path]
+    path = target_dir / ".git"
+    using_git = path.exists()
+
+    # if using_git:
+    #     cmd = 'git ls-files "*.py"'
+    #     cmd_parts = shlex.split(cmd)
+    #     py_files = subprocess.run(cmd_parts, capture_output=True).stdout.decode().strip().splitlines()
+
+    #     # Don't modify any test-related files.
+    #     py_files = [Path(f) for f in py_files]
+    #     py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
+
+    #     return py_files
+
+    # Project does not seem to be using Git. Return all .py files not in .venv, and
+    # outside of any tests/ dir, build/ dir, or dist/ dir.
+
+    py_files = target_dir.rglob("*.py")
+    py_files = [pf for pf in py_files if ".venv/" not in pf.as_posix()]
+    py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
+    py_files = [pf for pf in py_files if "build/" not in pf.as_posix()]
+    py_files = [pf for pf in py_files if "dist/" not in pf.as_posix()]
+    breakpoint()
+
+
+    sys.exit()
+
+    return py_files

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -1,0 +1,7 @@
+"""Utilities for working with the target project's files and directories."""
+
+def get_py_files(target_dir):
+    """Get all the .py files we can consider modifying when introducing bugs."""
+    py_files = target_dir.glob("*.py")
+    path = next(py_files)
+    return [path]

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -11,28 +11,23 @@ def get_py_files(target_dir):
     path = target_dir / ".git"
     using_git = path.exists()
 
-    # if using_git:
-    #     cmd = 'git ls-files "*.py"'
-    #     cmd_parts = shlex.split(cmd)
-    #     py_files = subprocess.run(cmd_parts, capture_output=True).stdout.decode().strip().splitlines()
+    if using_git:
+        cmd = 'git ls-files "*.py"'
+        cmd_parts = shlex.split(cmd)
+        py_files = subprocess.run(cmd_parts, capture_output=True).stdout.decode().strip().splitlines()
 
-    #     # Don't modify any test-related files.
-    #     py_files = [Path(f) for f in py_files]
-    #     py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
+        # Don't modify any test-related files.
+        py_files = [Path(f) for f in py_files]
+        py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
 
-    #     return py_files
+        return py_files
 
     # Project does not seem to be using Git. Return all .py files not in .venv, and
     # outside of any tests/ dir, build/ dir, or dist/ dir.
-
     py_files = target_dir.rglob("*.py")
     py_files = [pf for pf in py_files if ".venv/" not in pf.as_posix()]
     py_files = [pf for pf in py_files if "tests/" not in pf.as_posix()]
     py_files = [pf for pf in py_files if "build/" not in pf.as_posix()]
     py_files = [pf for pf in py_files if "dist/" not in pf.as_posix()]
-    breakpoint()
-
-
-    sys.exit()
 
     return py_files

--- a/tests/unit_tests/test_file_utils.py
+++ b/tests/unit_tests/test_file_utils.py
@@ -14,6 +14,7 @@ def test_get_py_files_git():
     root_dir = Path(__file__).parents[2]
     py_files = file_utils.get_py_files(root_dir)
     filenames = [pf.name for pf in py_files]
+
     assert "__init__.py" in filenames
     assert "cli.py" in filenames
     assert "cli_messages.py" in filenames
@@ -26,4 +27,23 @@ def test_get_py_files_git():
 
 def test_get_py_files_non_git(tmp_path_factory):
     """Test function for getting .py files from a dir not managed by Git."""
-    ...
+    # Build a tmp dir with some files that should be gathered, and some that 
+    # should not.
+    tmp_path = tmp_path_factory.mktemp("sample_non_git_dir")
+
+    path_tests = Path(tmp_path) / "tests"
+    path_tests.mkdir()
+
+    files = ["hello.py", "goodbye.py", "conftest.py", "tests/test_project.py"]
+    for file in files:
+        path = tmp_path / file
+        path.touch()
+
+    py_files = file_utils.get_py_files(tmp_path)
+    filenames = [pf.name for pf in py_files]
+
+    assert "hello.py" in filenames
+    assert "goodbye.py" in filenames
+
+    assert "conftest.py" not in filenames
+    assert "test_project.py" not in filenames

--- a/tests/unit_tests/test_file_utils.py
+++ b/tests/unit_tests/test_file_utils.py
@@ -1,0 +1,29 @@
+"""Tests for utils/file_utils.py."""
+
+from pathlib import Path
+
+import pytest
+
+from py_bugger.utils import file_utils
+
+
+def test_get_py_files_git():
+    # This takes more setup. Need to actually initialize a Git dir. Could point it
+    # at this project directory and just test a few files that should show up, and
+    # some that should be excluded.
+    root_dir = Path(__file__).parents[2]
+    py_files = file_utils.get_py_files(root_dir)
+    filenames = [pf.name for pf in py_files]
+    assert "__init__.py" in filenames
+    assert "cli.py" in filenames
+    assert "cli_messages.py" in filenames
+    assert "py_bugger.py" in filenames
+    assert "file_utils.py" in filenames
+
+    assert "test_file_utils.py" not in filenames
+    assert "test_basic_behavior.py" not in filenames
+    assert "conftest.py" not in filenames
+
+def test_get_py_files_non_git(tmp_path_factory):
+    """Test function for getting .py files from a dir not managed by Git."""
+    ...


### PR DESCRIPTION
Walk filetree, rather than just looking for first .py file. Use Git if it's being used, otherwise glob but ignore tests, venv, build-related files.