### PR TITLE
Test for preservation of trailing newlines at end of file

### DIFF
--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -17,7 +17,7 @@ def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
     path_dst = tmp_path / e2e_config.path_simple_indent.name
-    shutil.copyfile(e2e_config.path_simple_indent, path_dst)
+    shutil.copyfile(e2e_config.path_dog, path_dst)
 
     # Run py-bugger against file.
     cmd = f"py-bugger --exception-type IndentationError --target-file {path_dst.as_posix()}"
@@ -40,7 +40,7 @@ def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "simple_indent_no_trailing_newline.py"
+    path_src = e2e_config.path_sample_scripts / "dog_no_trailing_newline.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -8,8 +8,11 @@ import filecmp
 import os
 import sys
 
+import pytest
 
-def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
+
+@pytest.mark.parametrize("exception_type", ["IndentationError"])
+def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config, exception_type):
     """Test that trailing newlines are preserved when present."""
 
     # Copy sample code to tmp dir.
@@ -20,7 +23,7 @@ def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
     shutil.copyfile(e2e_config.path_dog, path_dst)
 
     # Run py-bugger against file.
-    cmd = f"py-bugger --exception-type IndentationError --target-file {path_dst.as_posix()}"
+    cmd = f"py-bugger --exception-type {exception_type} --target-file {path_dst.as_posix()}"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 
@@ -33,7 +36,8 @@ def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
     assert lines[-1] == ""
 
 
-def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config):
+@pytest.mark.parametrize("exception_type", ["IndentationError"])
+def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config, exception_type):
     """Test that trailing newlines are not introduced when not originally present."""
 
     # Copy sample code to tmp dir.
@@ -45,7 +49,7 @@ def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config):
     shutil.copyfile(path_src, path_dst)
 
     # Run py-bugger against file.
-    cmd = f"py-bugger --exception-type IndentationError --target-file {path_dst.as_posix()}"
+    cmd = f"py-bugger --exception-type {exception_type} --target-file {path_dst.as_posix()}"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -1,0 +1,34 @@
+"""Tests for behavior not specifically related to making bugs.
+"""
+
+import shutil
+import shlex
+import subprocess
+import filecmp
+import os
+import sys
+
+
+def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
+    """Test that trailing newlines are preserved when present."""
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_dst = tmp_path / e2e_config.path_simple_indent.name
+    shutil.copyfile(e2e_config.path_simple_indent, path_dst)
+
+    # Run py-bugger against file.
+    cmd = f"py-bugger --exception-type IndentationError --target-file {path_dst.as_posix()}"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
+
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+
+    assert "All requested bugs inserted." in stdout
+
+    # Check that last line is blank.
+    lines = path_dst.read_text().splitlines()
+    breakpoint()
+    assert lines[-1] == ""

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -30,5 +30,29 @@ def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config):
 
     # Check that last line is blank.
     lines = path_dst.read_text().splitlines()
-    breakpoint()
     assert lines[-1] == ""
+
+
+def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config):
+    """Test that trailing newlines are not introduced when not originally present."""
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = e2e_config.path_sample_scripts / "simple_indent_no_trailing_newline.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Run py-bugger against file.
+    cmd = f"py-bugger --exception-type IndentationError --target-file {path_dst.as_posix()}"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
+
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+
+    assert "All requested bugs inserted." in stdout
+
+    # Check that last line is not blank.
+    lines = path_dst.read_text().splitlines()
+    assert lines[-1] != ""

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 
-@pytest.mark.parametrize("exception_type", ["IndentationError"])
+@pytest.mark.parametrize("exception_type", ["IndentationError", "AttributeError"])
 def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config, exception_type):
     """Test that trailing newlines are preserved when present."""
 
@@ -36,7 +36,7 @@ def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config, exc
     assert lines[-1] == ""
 
 
-@pytest.mark.parametrize("exception_type", ["IndentationError"])
+@pytest.mark.parametrize("exception_type", ["IndentationError", "AttributeError"])
 def test_preserve_file_ending_no_trailing_newline(tmp_path_factory, e2e_config, exception_type):
     """Test that trailing newlines are not introduced when not originally present."""
 

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -11,6 +11,8 @@ import sys
 import pytest
 
 
+# Skip this test until resuming work on #39.
+@pytest.mark.skip
 @pytest.mark.parametrize("exception_type", ["IndentationError", "AttributeError"])
 def test_preserve_file_ending_trailing_newline(tmp_path_factory, e2e_config, exception_type):
     """Test that trailing newlines are preserved when present."""

--- a/tests/sample_code/sample_scripts/dog_no_trailing_newline.py
+++ b/tests/sample_code/sample_scripts/dog_no_trailing_newline.py
@@ -1,0 +1,10 @@
+class Dog:
+    def __init__(self, name):
+        self.name = name
+
+    def say_hi(self):
+        print(f"Hi, I'm {self.name} the dog!")
+
+
+dog = Dog("Willie")
+dog.say_hi()

--- a/tests/sample_code/sample_scripts/simple_indent_no_trailing_newline.py
+++ b/tests/sample_code/sample_scripts/simple_indent_no_trailing_newline.py
@@ -1,0 +1,2 @@
+for num in [1, 2, 3]:
+    print(num)

--- a/tests/sample_code/sample_scripts/simple_indent_no_trailing_newline.py
+++ b/tests/sample_code/sample_scripts/simple_indent_no_trailing_newline.py
@@ -1,2 +1,0 @@
-for num in [1, 2, 3]:
-    print(num)


### PR DESCRIPTION
This adds tests to support work on #39. PyCon sprints are about to start, and I want to merge these tests before any unrelated sprint work happens. 