### PR TITLE
Check for a clean Git status before modifying any of the user's files. (#36)

### DIFF
--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -3,6 +3,7 @@ import random
 
 from py_bugger import buggers
 from py_bugger.utils import file_utils
+from py_bugger.utils.git_utils import clean_git_status
 
 from py_bugger.cli.config import pb_config
 from py_bugger.cli import cli_messages
@@ -14,6 +15,9 @@ if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
 
 
 def main():
+    # Ensure safe working state
+    clean_git_status(force=pb_config.force)
+
     # Get a list of .py files we can consider modifying.
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 

--- a/src/py_bugger/utils/git_utils.py
+++ b/src/py_bugger/utils/git_utils.py
@@ -1,0 +1,47 @@
+import subprocess
+import warnings
+
+def clean_git_status(force=False):
+    """
+    Checks whether the current working directory is a clean Git repository.
+
+    This function verifies that the directory is under Git version control and
+    that there are NO uncommitted changes (staged, unstaged, or untracked files).
+    If the `force` parameter is set to True, the check is skipped and a warning
+    is issued. Skipping this check is not recommended, as it may result in
+    modifying files with uncommitted changes.
+
+    Parameters:
+        force (bool): If True, bypass the Git cleanliness check and issue a warning.
+
+    Raises:
+        RuntimeError: If Git is not installed or not found in PATH.
+        RuntimeError: If the current directory is not a Git repository.
+        RuntimeError: If uncommitted changes are detected and `force` is False.
+    """
+    if force:
+        warnings.warn(
+            "Skipping Git cleanliness check with --force. "
+            "This is not recommended, as it may overwrite uncommitted changes."
+        )
+        return
+
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+    except FileNotFoundError:
+        raise RuntimeError("Git is not installed or not found in PATH.")
+
+    except subprocess.CalledProcessError:
+        raise RuntimeError("Failed to run `git status`. Are you in a Git repository?")
+
+    if result.stdout.strip():
+        raise RuntimeError(
+            "Uncommitted changes found. Please commit or stash them, "
+            "or use --force to proceed (not recommended)."
+        )

--- a/tests/unit_tests/test_git_utils.py
+++ b/tests/unit_tests/test_git_utils.py
@@ -1,0 +1,64 @@
+import subprocess
+import tempfile
+import shutil
+import os
+from pathlib import Path
+import pytest
+
+from py_bugger.utils.git_utils import clean_git_status
+
+
+# Creates a temporary Git repo with one committed Python file.
+# This is used to test Git-related behavior in isolation.
+@pytest.fixture
+def clean_git_repo():
+    temp_dir = tempfile.mkdtemp()
+    subprocess.run(["git", "init"], cwd=temp_dir, check=True)
+
+    file_path = Path(temp_dir) / "sample.py"
+    file_path.write_text("print('hello')\n")
+
+    subprocess.run(["git", "add", "sample.py"], cwd=temp_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=temp_dir, check=True)
+
+    yield Path(temp_dir)
+
+    # Always clean up the temp directory afterward
+    shutil.rmtree(temp_dir)
+
+
+# Helper function to run clean_git_status from inside a target directory.
+# I use this to simulate running the check in an actual project folder.
+def clean_git_status_in_repo(repo_path, force=False):
+    original_cwd = os.getcwd()
+    os.chdir(repo_path)
+    try:
+        clean_git_status(force=force)
+    finally:
+        os.chdir(original_cwd)
+
+
+# Should pass when the repo is clean and force is False.
+# This is the "normal case" where everything is set up correctly.
+def test_clean_repo_passes(clean_git_repo):
+    clean_git_status_in_repo(clean_git_repo, force=False)
+
+
+# Should raise an error when there are uncommitted changes.
+# I make a small change to the file but don't commit it.
+def test_dirty_repo_fails(clean_git_repo):
+    dirty_file = clean_git_repo / "sample.py"
+    dirty_file.write_text("print('modified')\n")
+
+    with pytest.raises(RuntimeError, match="Uncommitted changes found"):
+        clean_git_status_in_repo(clean_git_repo, force=False)
+
+
+# Should skip the Git cleanliness check if force=True.
+# This test simulates someone using the --force flag.
+def test_force_skips_dirty_check(clean_git_repo):
+    dirty_file = clean_git_repo / "sample.py"
+    dirty_file.write_text("print('forced')\n")
+
+    # Should not raise any errors even though the repo is dirty. User still gets warning though!
+    clean_git_status_in_repo(clean_git_repo, force=True)


### PR DESCRIPTION
This PR addresses Task 1 from [Issue #36](https://github.com/ehmatthes/py-bugger/issues/36): Checking for a clean Git working directory before modifying any files.

## Summary of Changes:
- Added `clean_git_status(force=False)` in `git_utils.py`
- Issues a warning if the check is bypassed using `--force`
- Integrated the check into the bug injection workflow

## Wrote unit tests covering:
- Successful run in a clean Git repo
- Runtime error when uncommitted changes are present
- Successful run with `--force` despite dirty state (with warning to user)
- Skipped testing for rare edge cases like Git not being installed

## Rationale: 
This protects users from unintentionally modifying files in a dirty working directory, making py-bugger safer and more predictable to use.

## Testing:
- All tests pass using `pytest`
- `git_utils.py` has 71% of code coverage according to `pytest --cov`

Completes Task 1 from [Issue #36](https://github.com/ehmatthes/py-bugger/issues/36)