### PR TITLE
Increase the kinds of bugs that induce an IndentationError. (#36)

### DIFF
--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -129,7 +129,17 @@ def indentation_error_bugger(py_files):
     # Modify each relevant path.
     bugs_added = 0
     for path, target_line in paths_lines_modify:
-        if bug_utils.add_indentation(path, target_line):
+    # Randomly choose which type of indentation error to introduce. 
+    # I tried to follow your function's logic, and eventually we could just combine them.
+    # I didn't want to suggest too many fundamental changes to existing codebase, hence implementing random choice.
+        strategy = random.choice(["add", "mess"])
+
+        if strategy == "add":
+            modified = bug_utils.add_indentation(path, target_line)
+        else:
+            modified = bug_utils.mess_up_indentation(path, target_line)
+
+        if modified:
             _report_bug_added(path)
             bugs_added += 1
 

--- a/src/py_bugger/utils/bug_utils.py
+++ b/src/py_bugger/utils/bug_utils.py
@@ -75,3 +75,36 @@ def add_indentation(path, target_line):
     path.write_text(modified_source)
 
     return indentation_added
+
+
+def mess_up_indentation(path, target_line):
+    """
+    Randomly mess with indentation of the target line.
+    Options: indent, dedent, or bad-indent.
+    """
+    lines = path.read_text().splitlines()
+    modified_lines = []
+    modified = False
+
+    for line in lines:
+        if line == target_line and not modified:
+            leading_spaces = len(line) - len(line.lstrip(" "))
+            indent_unit = 4 if leading_spaces % 4 == 0 else 2
+            action = random.choice(["indent", "dedent", "bad-indent"])
+
+            if action == "indent":
+                line = " " * indent_unit + line
+            elif action == "dedent" and leading_spaces >= indent_unit:
+                line = line[indent_unit:]
+            elif action == "bad-indent":
+                line = " " * (indent_unit + 1) + line.lstrip(" ")
+
+            modified = True
+
+        modified_lines.append(line)
+
+    if modified:
+        path.write_text("\n".join(modified_lines))
+        return True
+        
+    return False


### PR DESCRIPTION
This PR addresses Task 2 from [Issue #36](https://github.com/ehmatthes/py-bugger/issues/36):
- Increase the kinds of bugs that induce an `IndentationError`. 
- See `indentation_error_bugger()` in `src/py_bugger/buggers.py`. It currently only adds indentation. 
- We can probably identify the unit indentation size, and then indent or dedent any line that would result in an `IndentationError`.

## Summary of Changes:
Added `mess_up_indentation(path, target_line)` to `bug_utils.py` to offer random selection between:
- Adding one indentation level
- Removing one indentation level (`dedent`)
- Applying incorrect indentation (like 5 spaces)

Modified `indentation_error_bugger()` in `buggers.py` to randomly select between:
- The existing `add_indentation()` approach
- The new `mess_up_indentation()` strategy

## Wrote unit tests covering:
- Indentation is added (`indent`)
- Indentation is removed (`dedent`)
- Incorrect indentation is applied (`bad-indent`)
- Function returns `True` when a line is modified
- Function returns `False` when the target line is not found

## Rationale
This improves the realism and variety of indentation bugs introduced by `py-bugger`, increasing its value for testing code robustness and educational scenarios.

## Testing:
- All tests pass using `pytest`
- `bug_utils.py` has now 81% of code coverage according to `pytest --cov`

Completes Task 2 from [Issue #36](https://github.com/ehmatthes/py-bugger/issues/36)