### PR TITLE
Suggestions of projects for py-bugger practice. (#36)

### DIFF
--- a/docs/debugging_projects.md
+++ b/docs/debugging_projects.md
@@ -1,0 +1,22 @@
+# Suggestions of projects for py-bugger practice
+This list includes open-source projects that could be ideal for practicing debugging with tools like `py-bugger`. 
+
+Observations:
+- I didn't run their test suites, but, based on my experience using some of these libraries/packages, I would expect failure times to be **~2-3 minutes or less** (not necessarily running the whole test suite though).
+- These projects are particularly appealing for debugging practice because they offer **clear visual feedback** through terminal outputs and rendered UIs or **immediate syntax/runtime failures** when bugs are introduced.
+
+Projects listed here:
+- Are actively maintained
+- Provide fast failure feedback on tests
+- Offer relevant opportunities to practice inducing and diagnosing bugs
+
+| Project | Description | Reason |
+|--------|-------------|---------------|
+| [rich](https://github.com/Textualize/rich) | Terminal formatting | Visual feedback and modular code |
+| [httpx](https://github.com/encode/httpx) | Async HTTP client | Great for I/O bugs and async tracing |
+| [black](https://github.com/psf/black) | Code formatter | Deterministic behavior, regression testing |
+| [py-shinywidgets](https://github.com/posit-dev/py-shinywidgets) | Widgets for Shiny apps | Component-level testing and user interaction logic |
+| [pydantic](https://github.com/pydantic/pydantic) | Type-based validation | Complex logic with excellent coverage |
+| [typer](https://github.com/tiangolo/typer) | CLI builder | Good for simulating user input/output |
+| [Shiny for Python](https://github.com/posit-dev/py-shiny) | Web framework for interactive data apps | Modular code, fast tests, good UI/server bug surface |
+| [python-dateutil](https://github.com/dateutil/dateutil) | Date/time parsing | Handles real-world edge cases |


### PR DESCRIPTION
This PR addresses Task 3 from [Issue #36](https://github.com/ehmatthes/py-bugger/issues/36): Identify well-tested projects, with tests that run in under 2 minutes, that are good for debugging practice.

## Summary of Changes:
- Added a new Markdown file: `docs/debugging-projects.md`
- The file lists 8 open-source projects that could be well-suited for debugging practice with `py-bugger`
- Each entry includes a description and rationale for why the project is useful for practicing bug injection and detection

## Rationale:
These projects were chosen because they:
- Are actively maintained
- Provide fast test feedback (typically under 2–3 minutes)
- Offer visually or structurally obvious failure modes, which makes them great candidates for practicing with `py-bugger` _(i.e., small_ changes to scripts can most likely trigger **drastic, obvious bugs**)

## Notes:
- I did not benchmark full test suite runtimes, but the selected projects are based on familiarity and prior experience.
- Emphasis was placed on visual feedback, modularity, and reliability of test outcomes when bugs are introduced.

This PR completes Task 3 from Issue #36.