### PR TITLE
Remove elif, else, case, except, and finally from targets for IndentationError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ Changelog: python-bugger
 
 Can request more than one type of exception to be induced.
 
-### Unreleased
+### 0.3.5
 
 #### External changes
 
-- 
+- Removes else, elif, case, except and finally from targets for IndentationError for now.
 
 #### Internal changes
 
 - Added a release script.
+- Partial implementation of a test for handling tabs correctly.
 
 ### 0.3.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-bugger"
 description = "Practice debugging, by intentionally introducing bugs into an existing codebase."
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 requires-python = ">=3.9"
 
 dependencies = ["libcst", "click"]

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -112,10 +112,7 @@ def indentation_error_bugger(py_files):
         "if",
         "with",
         "match",
-        "case",
         "try",
-        "except",
-        "finally",
     ]
     paths_lines = file_utils.get_paths_lines(py_files, targets=targets)
 

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -111,7 +111,6 @@ def indentation_error_bugger(py_files):
         "class",
         "if",
         "elif",
-        "else",
         "with",
         "match",
         "case",

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -110,7 +110,6 @@ def indentation_error_bugger(py_files):
         "def",
         "class",
         "if",
-        "elif",
         "with",
         "match",
         "case",

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -483,7 +483,7 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     shutil.copyfile(e2e_config.path_all_indentation_blocks, path_dst)
 
     # Run py-bugger against directory.
-    cmd = f"py-bugger --exception-type IndentationError --num-bugs 12 --target-dir {tmp_path.as_posix()}"
+    cmd = f"py-bugger --exception-type IndentationError --num-bugs 11 --target-dir {tmp_path.as_posix()}"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -12,6 +12,8 @@ import filecmp
 import os
 import sys
 
+import pytest
+
 
 # --- Test functions ---
 
@@ -438,6 +440,41 @@ def test_indentation_error_simple(tmp_path_factory, e2e_config):
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
     assert 'simple_indent.py", line 1' in stderr
+
+
+# This test passes, but it mixes tabs and spaces. It would fail if the 
+# for loop was inside a function. Make a test file with the for loop
+# in the function, induce an error that indents the for line, not the 
+# def line, and assert not TabError.
+@pytest.mark.skip()
+def test_indentation_error_simple_tab(tmp_path_factory, e2e_config):
+    """py-bugger --exception-type IndentationError
+
+    Run against a file with a single indented block, using a tab delimiter.
+    """
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = e2e_config.path_sample_scripts / "simple_indent_tab.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --exception-type IndentationError --target-dir {tmp_path.as_posix()}"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
+
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+
+    assert "All requested bugs inserted." in stdout
+
+    # Run file, should raise IndentationError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert "IndentationError: unexpected indent" in stderr
+    assert 'simple_indent_tab.py", line 1' in stderr
 
 
 def test_indentation_error_complex(tmp_path_factory, e2e_config):

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -532,5 +532,4 @@ def test_indentation_else_block(tmp_path_factory, e2e_config):
     cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
-    assert "IndentationError: unexpected indent" in stderr
-    # assert 'all_indentation_blocks.py", line 1' in stderr
+    assert "SyntaxError: invalid syntax" not in stderr

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -483,7 +483,7 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     shutil.copyfile(e2e_config.path_all_indentation_blocks, path_dst)
 
     # Run py-bugger against directory.
-    cmd = f"py-bugger --exception-type IndentationError --num-bugs 9 --target-dir {tmp_path.as_posix()}"
+    cmd = f"py-bugger --exception-type IndentationError --num-bugs 8 --target-dir {tmp_path.as_posix()}"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -497,3 +497,40 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
     assert 'all_indentation_blocks.py", line 1' in stderr
+
+
+def test_indentation_else_block(tmp_path_factory, e2e_config):
+    """Test that an indendented else block does not result in a SyntaxError.
+
+    If the else block is moved to its own indentation level, -> IndentationError.
+    If it matches the indentation level of the parent's block, ie the if's block,
+    it will result in a Syntax Error:
+
+    if True:
+        print("Hi.")
+        else:
+        print("Bye.")
+    """
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = e2e_config.path_sample_scripts / "else_block.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --exception-type IndentationError --target-dir {tmp_path.as_posix()}"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
+
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+
+    assert "All requested bugs inserted." in stdout
+
+    # Run file, should raise IndentationError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert "IndentationError: unexpected indent" in stderr
+    # assert 'all_indentation_blocks.py", line 1' in stderr

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -483,7 +483,7 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     shutil.copyfile(e2e_config.path_all_indentation_blocks, path_dst)
 
     # Run py-bugger against directory.
-    cmd = f"py-bugger --exception-type IndentationError --num-bugs 11 --target-dir {tmp_path.as_posix()}"
+    cmd = f"py-bugger --exception-type IndentationError --num-bugs 9 --target-dir {tmp_path.as_posix()}"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 

--- a/tests/sample_code/sample_scripts/else_block.py
+++ b/tests/sample_code/sample_scripts/else_block.py
@@ -1,0 +1,6 @@
+if True:
+    print("Hi.")
+elif False:
+    pass
+else:
+    print("Bye.")

--- a/tests/sample_code/sample_scripts/else_block.py
+++ b/tests/sample_code/sample_scripts/else_block.py
@@ -1,6 +1,7 @@
 if True:
     print("Hi.")
 elif False:
+    # This block just lets the random seed affect the else block.
     pass
 else:
     print("Bye.")

--- a/tests/sample_code/sample_scripts/simple_indent_tab.py
+++ b/tests/sample_code/sample_scripts/simple_indent_tab.py
@@ -1,0 +1,2 @@
+for num in [1, 2, 3]:
+	print(num)


### PR DESCRIPTION
See #38. These need to be handled more carefully, otherwise they induce a SyntaxError instead of an IndentationError.