### PR TITLE
Make the `--exception-type` argument optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Changelog: python-bugger
 
 Looks for a clean Git status before introducing bugs.
 
+### 0.4.1
+
+#### External changes
+
+- The `--exception-type` argument is now optional. When it's omitted, one of the supported exception types is chosen randomly.
+- Passing `--num-args` still works, but each bug induces the same kind of exception.
+- If there's a typo in the value for `--exception-type`, a suggestion is made. Users still need to revise their command, it does not prompt to use the suggested value at this point.
+- Fixes a bug where running py-bugger from a directory under version control, against a target directory that's also under version control, runs Git commands against the first directory instead of the target.
+
+#### Internal changes
+
+- Uses `SUPPORTED_EXCEPTION_TYPES` from `py_bugger.cli.config` anywhere a list of supported exception types is needed.
+- All handling of `--num-args` takes place in the main py_bugger.py file.
+- Tracks each bug that's introduced, so each node or line can't be modified more than once. There's a new `Modification` model that's used to track each modification that's made to the user's code. This also simplifies tracking the number of bugs, which can always be determined from `len(modifications)`.
+- Some light ongoing refactoring work has been done through this point release.
+
 ### 0.4.0
 
 #### External changes

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -37,6 +37,14 @@ Currently, you can create multiple bugs that target any of the supported excepti
 $ py-bugger -e IndentationError --n 3
 ```
 
+## Introducing a random bug
+
+The `--exception-type` argument is optional. If you leave it out, py-bugger will choose which type of exception to induce randomly:
+
+```sh
+$ py-bugger
+```
+
 ## Introducing multiple bugs of different types
 
 Currently, it's not possible to specify more than one exception type in a single `py-bugger` call. You may have luck running `py-bugger` multiple times, with different exception types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-bugger"
 description = "Practice debugging, by intentionally introducing bugs into an existing codebase."
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.9"
 
 dependencies = ["libcst", "click"]

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -39,7 +39,7 @@ def module_not_found_bugger(py_files):
         # modifier code to handle these nodes.
         # For diagnostics, can run against Pillow with -n set to a
         # really high number.
-        ...
+        raise
     else:
         path.write_text(modified_tree.code)
         _report_bug_added(path)

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -1,6 +1,6 @@
 """Utilities for introducing specific kinds of bugs."""
 
-import libcst as cst
+import libcst
 import random
 
 from py_bugger.utils import cst_utils
@@ -26,8 +26,20 @@ def module_not_found_bugger(py_files):
     if not paths_nodes:
         return False
 
-    # Randomly select a node to focus on.
-    path, node = random.choice(paths_nodes)
+    # Randomly select a node to focus on; make sure not to reuse a node.
+    random.shuffle(paths_nodes)
+    proceed = False
+    while paths_nodes:
+        path, node = paths_nodes.pop()
+        if file_utils.node_line_unmodified(path, candidate_node=node):
+            proceed = True
+            break
+
+    # Bail if all nodes have already been modified.
+    if not proceed:
+        return False
+
+
     source = path.read_text()
     tree = cst.parse_module(source)
 

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -25,17 +25,36 @@ def module_not_found_bugger(py_files):
 
     # Randomly select a node to focus on, making sure not to choose a node that's
     # already had a bug introduced to it.
-    random.shuffle(paths_nodes)
-    proceed = False
-    while paths_nodes:
-        path, node = paths_nodes.pop()
-        if file_utils.check_unmodified(path, candidate_node=node):
-            proceed = True
-            break
+    # random.shuffle(paths_nodes)
+    # proceed = False
+    # while paths_nodes:
+    #     path, node = paths_nodes.pop()
+    #     if file_utils.check_unmodified(path, candidate_node=node):
+    #         proceed = True
+    #         break
 
-    # Bail if all nodes have already been modified.
-    if not proceed:
+    # # Bail if all nodes have already been modified.
+    # if not proceed:
+    #     return False
+
+
+
+    # Randomly select a node to focus on, making sure not to choose a node that's
+    # already had a bug introduced to it.
+    random.shuffle(paths_nodes)
+    for path, node in paths_nodes:
+        if file_utils.check_unmodified(path, candidate_node=node):
+            break
+    else:
+        # All nodes have already been modified to introduce a previous bug.
         return False
+
+
+
+
+
+
+
 
     source = path.read_text()
     tree = cst.parse_module(source)

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -93,7 +93,7 @@ def indentation_error_bugger(py_files):
     doesn't make it easy to create invalid syntax.
 
     Returns:
-        Int: Number of bugs made.
+        Bool: Whether a bug was introduced or not.
     """
     # Find relevant files and lines.
     targets = [
@@ -112,27 +112,6 @@ def indentation_error_bugger(py_files):
     if bug_utils.add_indentation(path, target_line):
         _report_bug_added(path)
         return True
-
-
-
-
-
-
-
-    # Select the set of lines to modify. If num_bugs is greater than the number
-    # of lines, just change each line.
-    # num_changes = min(len(paths_lines), pb_config.num_bugs)
-    # paths_lines_modify = random.sample(paths_lines, k=num_changes)
-
-
-    # Modify each relevant path.
-    # bugs_added = 0
-    # for path, target_line in paths_lines_modify:
-    #     if bug_utils.add_indentation(path, target_line):
-    #         _report_bug_added(path)
-    #         bugs_added += 1
-
-    # return bugs_added
 
 
 # --- Helper functions ---

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -74,7 +74,7 @@ def attribute_error_bugger(py_files):
 
     # Modify user's code.
     try:
-        modified_tree = tree.visit(cst_utils.AttributeModifier(node, node_index))
+        modified_tree = tree.visit(cst_utils.AttributeModifier(node, node_index, path))
     except TypeError:
         # DEV: Figure out which nodes are ending up here, and update
         # modifier code to handle these nodes.

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -17,16 +17,17 @@ def module_not_found_bugger(py_files):
     """Induce a ModuleNotFoundError.
 
     Returns:
-        Int: Number of bugs made.
+        Bool: Whether a bug was introduced or not.
     """
-    # Find all relevant nodes, choose a random one to modify.
+    # Find all relevant nodes.
     paths_nodes = cst_utils.get_paths_nodes(py_files, node_type=cst.Import)
 
+    # Bail if there are no relevant nodes.
     if not paths_nodes:
         return False
 
+    # Randomly select a node to focus on.
     path, node = random.choice(paths_nodes)
-
     source = path.read_text()
     tree = cst.parse_module(source)
 
@@ -42,8 +43,7 @@ def module_not_found_bugger(py_files):
     else:
         path.write_text(modified_tree.code)
         _report_bug_added(path)
-
-    return True
+        return True
 
 
 def attribute_error_bugger(py_files):

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -49,19 +49,17 @@ def attribute_error_bugger(py_files):
     Returns:
         Bool: Whether a bug was introduced or not.
     """
-    # Find all relevant nodes.
-    paths_nodes = cst_utils.get_paths_nodes(py_files, node_type=cst.Attribute)
-
-    # Bail if there are no relevant nodes.
-    if not paths_nodes:
+    # Get a random node that hasn't already been modified.
+    path, node = _get_random_node(py_files, node_type=cst.Attribute)
+    if not path:
         return False
 
-    # Randomly select a node to focus on.
-    path, node = random.choice(paths_nodes)
+    # Parse user's code.
     source = path.read_text()
     tree = cst.parse_module(source)
 
     # Pick node to modify if more than one match in the file.
+    # Note that not all bugger functions need this step.
     node_count = cst_utils.count_nodes(tree, node)
     if node_count > 1:
         node_index = random.randrange(0, node_count - 1)

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -1,4 +1,10 @@
-"""Utilities for introducing specific kinds of bugs."""
+"""Utilities for introducing specific kinds of bugs.
+
+DEV: Don't rush to refactor bugger functions. for example, it's not yet clear whether this should
+be a class. Also, not sure we need separate bugger functions, or one bugger function with some
+conditional logic. Implement support for another exception type, and logical errors, and see what
+things are looking like.
+"""
 
 import libcst as cst
 import random

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -33,7 +33,7 @@ def module_not_found_bugger(py_files):
 
     # Modify user's code.
     try:
-        modified_tree = tree.visit(cst_utils.ImportModifier(node))
+        modified_tree = tree.visit(cst_utils.ImportModifier(node, path))
     except TypeError:
         # DEV: Figure out which nodes are ending up here, and update
         # modifier code to handle these nodes.

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -23,14 +23,9 @@ def module_not_found_bugger(py_files):
     if not (paths_nodes := cst_utils.get_paths_nodes(py_files, node_type=cst.Import)):
         return False
 
-    # Randomly select a node to focus on. Make sure it's a node that hasn't
-    # already been modified.
-    random.shuffle(paths_nodes)
-    for path, node in paths_nodes:
-        if file_utils.check_unmodified(path, candidate_node=node):
-            break
-    else:
-        # All nodes have already been modified to introduce a previous bug.
+    # Get a random node that hasn't already been modified.
+    path, node = _get_random_node(paths_nodes)
+    if not path:
         return False
 
     source = path.read_text()
@@ -135,3 +130,17 @@ def _report_bug_added(path_modified):
         print(f"Added bug to: {path_modified.as_posix()}")
     else:
         print(f"Added bug.")
+
+def _get_random_node(paths_nodes):
+    """Randomly select a node to modify.
+    
+    Make sure it's a node that hasn't already been modified.
+    """
+    random.shuffle(paths_nodes)
+    for path, node in paths_nodes:
+        if file_utils.check_unmodified(path, candidate_node=node):
+            return path, node
+    else:
+        # All nodes have already been modified to introduce a previous bug.
+        # Returning two False values because we need to return a path and a node.
+        return False, False

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -19,14 +19,12 @@ def module_not_found_bugger(py_files):
     Returns:
         Bool: Whether a bug was introduced or not.
     """
-    # Find all relevant nodes.
-    paths_nodes = cst_utils.get_paths_nodes(py_files, node_type=cst.Import)
-
-    # Bail if there are no relevant nodes.
-    if not paths_nodes:
+    # Find all relevant nodes. Bail if there are no relevant nodes.
+    if not (paths_nodes := cst_utils.get_paths_nodes(py_files, node_type=cst.Import)):
         return False
 
-    # Randomly select a node to focus on; make sure not to reuse a node.
+    # Randomly select a node to focus on, making sure not to choose a node that's
+    # already had a bug introduced to it.
     random.shuffle(paths_nodes)
     proceed = False
     while paths_nodes:
@@ -38,7 +36,6 @@ def module_not_found_bugger(py_files):
     # Bail if all nodes have already been modified.
     if not proceed:
         return False
-
 
     source = path.read_text()
     tree = cst.parse_module(source)

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -107,6 +107,11 @@ def indentation_error_bugger(py_files):
         "try",
     ]
     paths_lines = file_utils.get_paths_lines(py_files, targets=targets)
+
+    # Bail if there are no relevant lines.
+    if not paths_lines:
+        return False
+
     path, target_line = random.choice(paths_lines)
 
     if bug_utils.add_indentation(path, target_line):

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -23,24 +23,8 @@ def module_not_found_bugger(py_files):
     if not (paths_nodes := cst_utils.get_paths_nodes(py_files, node_type=cst.Import)):
         return False
 
-    # Randomly select a node to focus on, making sure not to choose a node that's
-    # already had a bug introduced to it.
-    # random.shuffle(paths_nodes)
-    # proceed = False
-    # while paths_nodes:
-    #     path, node = paths_nodes.pop()
-    #     if file_utils.check_unmodified(path, candidate_node=node):
-    #         proceed = True
-    #         break
-
-    # # Bail if all nodes have already been modified.
-    # if not proceed:
-    #     return False
-
-
-
-    # Randomly select a node to focus on, making sure not to choose a node that's
-    # already had a bug introduced to it.
+    # Randomly select a node to focus on. Make sure it's a node that hasn't
+    # already been modified.
     random.shuffle(paths_nodes)
     for path, node in paths_nodes:
         if file_utils.check_unmodified(path, candidate_node=node):
@@ -48,13 +32,6 @@ def module_not_found_bugger(py_files):
     else:
         # All nodes have already been modified to introduce a previous bug.
         return False
-
-
-
-
-
-
-
 
     source = path.read_text()
     tree = cst.parse_module(source)

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -86,42 +86,6 @@ def attribute_error_bugger(py_files):
         return True
 
 
-
-    # # Select the set of nodes to modify. If num_bugs is greater than the number
-    # # of nodes, just change each node.
-    # num_changes = min(len(paths_nodes), pb_config.num_bugs)
-    # paths_nodes_modify = random.sample(paths_nodes, k=num_changes)
-
-    # # Modify each relevant path.
-    # bugs_added = 0
-    # for path, node in paths_nodes_modify:
-    #     source = path.read_text()
-    #     tree = cst.parse_module(source)
-
-    #     # Pick node to modify if more than one match in the file.
-    #     node_count = cst_utils.count_nodes(tree, node)
-    #     if node_count > 1:
-    #         node_index = random.randrange(0, node_count - 1)
-    #     else:
-    #         node_index = 0
-
-    #     # Modify user's code.
-    #     try:
-    #         modified_tree = tree.visit(cst_utils.AttributeModifier(node, node_index))
-    #     except TypeError:
-    #         # DEV: Figure out which nodes are ending up here, and update
-    #         # modifier code to handle these nodes.
-    #         # For diagnostics, can run against Pillow with -n set to a
-    #         # really high number.
-    #         ...
-    #     else:
-    #         path.write_text(modified_tree.code)
-    #         _report_bug_added(path)
-    #         bugs_added += 1
-
-    # return bugs_added
-
-
 def indentation_error_bugger(py_files):
     """Induce an IndentationError.
 

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -107,20 +107,32 @@ def indentation_error_bugger(py_files):
         "try",
     ]
     paths_lines = file_utils.get_paths_lines(py_files, targets=targets)
+    path, target_line = random.choice(paths_lines)
+
+    if bug_utils.add_indentation(path, target_line):
+        _report_bug_added(path)
+        return True
+
+
+
+
+
+
 
     # Select the set of lines to modify. If num_bugs is greater than the number
     # of lines, just change each line.
-    num_changes = min(len(paths_lines), pb_config.num_bugs)
-    paths_lines_modify = random.sample(paths_lines, k=num_changes)
+    # num_changes = min(len(paths_lines), pb_config.num_bugs)
+    # paths_lines_modify = random.sample(paths_lines, k=num_changes)
+
 
     # Modify each relevant path.
-    bugs_added = 0
-    for path, target_line in paths_lines_modify:
-        if bug_utils.add_indentation(path, target_line):
-            _report_bug_added(path)
-            bugs_added += 1
+    # bugs_added = 0
+    # for path, target_line in paths_lines_modify:
+    #     if bug_utils.add_indentation(path, target_line):
+    #         _report_bug_added(path)
+    #         bugs_added += 1
 
-    return bugs_added
+    # return bugs_added
 
 
 # --- Helper functions ---

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -1,6 +1,6 @@
 """Utilities for introducing specific kinds of bugs."""
 
-import libcst
+import libcst as cst
 import random
 
 from py_bugger.utils import cst_utils

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -19,13 +19,40 @@ def module_not_found_bugger(py_files):
     Returns:
         Int: Number of bugs made.
     """
-    # Find all relevant nodes.
+    # Find all relevant nodes, choose a random one to modify.
     paths_nodes = cst_utils.get_paths_nodes(py_files, node_type=cst.Import)
+
+    if not paths_nodes:
+        return False
+        
+    path, node = random.choice(paths_nodes)
+
+    source = path.read_text()
+    tree = cst.parse_module(source)
+
+    # Modify user's code.
+    try:
+        modified_tree = tree.visit(cst_utils.ImportModifier(node))
+    except TypeError:
+        # DEV: Figure out which nodes are ending up here, and update
+        # modifier code to handle these nodes.
+        # For diagnostics, can run against Pillow with -n set to a
+        # really high number.
+        ...
+    else:
+        path.write_text(modified_tree.code)
+        _report_bug_added(path)
+
+    return True
+
+
+
 
     # Select the set of nodes to modify. If num_bugs is greater than the number
     # of nodes, just change each node.
-    num_changes = min(len(paths_nodes), pb_config.num_bugs)
-    paths_nodes_modify = random.sample(paths_nodes, k=num_changes)
+    # num_changes = min(len(paths_nodes), pb_config.num_bugs)
+    # paths_nodes_modify = random.sample(paths_nodes, k=num_changes)
+
 
     # Modify each relevant path.
     bugs_added = 0

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -24,7 +24,7 @@ def module_not_found_bugger(py_files):
 
     if not paths_nodes:
         return False
-        
+
     path, node = random.choice(paths_nodes)
 
     source = path.read_text()
@@ -44,37 +44,6 @@ def module_not_found_bugger(py_files):
         _report_bug_added(path)
 
     return True
-
-
-
-
-    # Select the set of nodes to modify. If num_bugs is greater than the number
-    # of nodes, just change each node.
-    # num_changes = min(len(paths_nodes), pb_config.num_bugs)
-    # paths_nodes_modify = random.sample(paths_nodes, k=num_changes)
-
-
-    # Modify each relevant path.
-    bugs_added = 0
-    for path, node in paths_nodes_modify:
-        source = path.read_text()
-        tree = cst.parse_module(source)
-
-        # Modify user's code.
-        try:
-            modified_tree = tree.visit(cst_utils.ImportModifier(node))
-        except TypeError:
-            # DEV: Figure out which nodes are ending up here, and update
-            # modifier code to handle these nodes.
-            # For diagnostics, can run against Pillow with -n set to a
-            # really high number.
-            ...
-        else:
-            path.write_text(modified_tree.code)
-            _report_bug_added(path)
-            bugs_added += 1
-
-    return bugs_added
 
 
 def attribute_error_bugger(py_files):

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -29,7 +29,7 @@ def module_not_found_bugger(py_files):
     proceed = False
     while paths_nodes:
         path, node = paths_nodes.pop()
-        if file_utils.node_line_unmodified(path, candidate_node=node):
+        if file_utils.check_unmodified(path, candidate_node=node):
             proceed = True
             break
 

--- a/src/py_bugger/cli/cli_messages.py
+++ b/src/py_bugger/cli/cli_messages.py
@@ -2,10 +2,6 @@
 
 # --- Static messages ---
 
-msg_exception_type_required = (
-    "You must be explicit about what kinds of errors you want to induce in the project."
-)
-
 msg_target_file_dir = (
     "Target file overrides target dir. Please only pass one of these args."
 )

--- a/src/py_bugger/cli/cli_messages.py
+++ b/src/py_bugger/cli/cli_messages.py
@@ -1,5 +1,8 @@
 """Messages for use in CLI output."""
 
+from py_bugger.cli.config import pb_config
+from py_bugger.utils.modification import modifications
+
 # --- Static messages ---
 
 msg_target_file_dir = (
@@ -11,11 +14,13 @@ msg_git_not_available = "Git does not seem to be available. It's highly recommen
 msg_unclean_git_status = "You have uncommitted changes in your project. It's highly recommended that you run py-bugger against a file or project with a clean Git status. You can ignore this check with the --ignore-git-status argument."
 
 
-def success_msg(num_added, num_requested):
+# def success_msg(num_added, num_requested):
+def success_msg():
     """Generate a success message at end of run."""
 
     # Show a final success/fail message.
-    if num_added == num_requested:
+    num_added = len(modifications)
+    if num_added == pb_config.num_bugs:
         return "All requested bugs inserted."
     elif num_added == 0:
         return "Unable to introduce any of the requested bugs."

--- a/src/py_bugger/cli/cli_messages.py
+++ b/src/py_bugger/cli/cli_messages.py
@@ -1,8 +1,5 @@
 """Messages for use in CLI output."""
 
-from py_bugger.cli.config import pb_config
-from py_bugger.utils.modification import modifications
-
 # --- Static messages ---
 
 msg_target_file_dir = (
@@ -17,6 +14,9 @@ msg_unclean_git_status = "You have uncommitted changes in your project. It's hig
 # def success_msg(num_added, num_requested):
 def success_msg():
     """Generate a success message at end of run."""
+    # Importing these here makes for a faster test suite.
+    from py_bugger.cli.config import pb_config
+    from py_bugger.utils.modification import modifications
 
     # Show a final success/fail message.
     num_added = len(modifications)

--- a/src/py_bugger/cli/cli_messages.py
+++ b/src/py_bugger/cli/cli_messages.py
@@ -11,9 +11,6 @@ msg_git_not_available = "Git does not seem to be available. It's highly recommen
 msg_unclean_git_status = "You have uncommitted changes in your project. It's highly recommended that you run py-bugger against a file or project with a clean Git status. You can ignore this check with the --ignore-git-status argument."
 
 
-# --- Dynamic messages ---
-
-
 def success_msg(num_added, num_requested):
     """Generate a success message at end of run."""
 
@@ -26,6 +23,17 @@ def success_msg(num_added, num_requested):
         msg = f"Inserted {num_added} bugs."
         msg += "\nUnable to introduce additional bugs of the requested type."
         return msg
+
+# Validation for exception type.
+def msg_apparent_typo(actual, expected):
+    """Suggest a typo fix for an exception type."""
+    msg = f"You specified {actual} for --exception-type. Did you mean {expected}?"
+    return msg
+
+def msg_unsupported_exception_type(exception_type):
+    """Specified an unsupported exception type."""
+    msg = f"The exception type {exception_type} is not currently supported."
+    return msg
 
 
 # Messagess for invalid --target-dir calls.
@@ -86,3 +94,4 @@ def msg_git_not_used(pb_config):
 
     msg = f"The {target} you're running py-bugger against does not seem to be under version control. It's highly recommended that you run py-bugger against a file or project with a clean Git status. You can ignore this check with the --ignore-git-status argument."
     return msg
+

--- a/src/py_bugger/cli/cli_utils.py
+++ b/src/py_bugger/cli/cli_utils.py
@@ -19,9 +19,6 @@ from py_bugger.cli.config import pb_config
 
 def validate_config():
     """Make sure the CLI options are valid."""
-    # if not pb_config.exception_type:
-    #     click.echo(cli_messages.msg_exception_type_required)
-    #     sys.exit()
 
     if pb_config.target_dir and pb_config.target_file:
         click.echo(cli_messages.msg_target_file_dir)

--- a/src/py_bugger/cli/cli_utils.py
+++ b/src/py_bugger/cli/cli_utils.py
@@ -66,9 +66,9 @@ def _validate_exception_type():
         return
 
     # Check for typos.
-    match = difflib.get_close_matches(pb_config.exception_type, SUPPORTED_EXCEPTION_TYPES, n=1)
-    if match:
-        msg = cli_messages.msg_apparent_typo(pb_config.exception_type, match)
+    matches = difflib.get_close_matches(pb_config.exception_type, SUPPORTED_EXCEPTION_TYPES, n=1)
+    if matches:
+        msg = cli_messages.msg_apparent_typo(pb_config.exception_type, matches[0])
         click.echo(msg)
         sys.exit()
 

--- a/src/py_bugger/cli/cli_utils.py
+++ b/src/py_bugger/cli/cli_utils.py
@@ -19,9 +19,9 @@ from py_bugger.cli.config import pb_config
 
 def validate_config():
     """Make sure the CLI options are valid."""
-    if not pb_config.exception_type:
-        click.echo(cli_messages.msg_exception_type_required)
-        sys.exit()
+    # if not pb_config.exception_type:
+    #     click.echo(cli_messages.msg_exception_type_required)
+    #     sys.exit()
 
     if pb_config.target_dir and pb_config.target_file:
         click.echo(cli_messages.msg_target_file_dir)

--- a/src/py_bugger/cli/config.py
+++ b/src/py_bugger/cli/config.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+SUPPORTED_EXCEPTION_TYPES = ["ModuleNotFoundError", "AttributeError", "IndentationError"]
+
+
 @dataclass
 class PBConfig:
     exception_type: str = ""

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -12,7 +12,7 @@ from py_bugger.cli import cli_messages
 # Set a random seed when testing.
 if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
     random.seed(int(seed))
-    
+
 
 def main():
     # Get a list of .py files we can consider modifying.

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -24,8 +24,6 @@ def main():
     # If --exception-type not specified, choose one.
     if not pb_config.exception_type:
         pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
-    print(pb_config.exception_type)
-    print("\nHERE")
 
     # Currently, handles just one exception type per call.
     # When multiple are supported, implement more complex logic for choosing which ones

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -38,8 +38,10 @@ def main():
             if buggers.module_not_found_bugger(py_files):
                 bugs_added += 1
         elif pb_config.exception_type == "AttributeError":
-            new_bugs_made = buggers.attribute_error_bugger(py_files)
-            bugs_added += new_bugs_made
+            # new_bugs_made = buggers.attribute_error_bugger(py_files)
+            # bugs_added += new_bugs_made
+            if buggers.attribute_error_bugger(py_files):
+                bugs_added += 1
         elif pb_config.exception_type == "IndentationError":
             new_bugs_made = buggers.indentation_error_bugger(py_files)
             bugs_added += new_bugs_made

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -12,7 +12,7 @@ from py_bugger.cli import cli_messages
 # Set a random seed when testing.
 if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
     random.seed(int(seed))
-
+    
 
 def main():
     # Get a list of .py files we can consider modifying.

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -3,7 +3,6 @@ import random
 
 from py_bugger import buggers
 from py_bugger.utils import file_utils
-from py_bugger.utils.modification import modifications
 
 from py_bugger.cli.config import pb_config
 from py_bugger.cli.config import SUPPORTED_EXCEPTION_TYPES
@@ -36,7 +35,5 @@ def main():
             buggers.indentation_error_bugger(py_files)
 
     # Show a final success/fail message.
-    bugs_added = len(modifications)
-    msg = cli_messages.success_msg(bugs_added, pb_config.num_bugs)
-    # msg = cli_messags.succes_msg()
+    msg = cli_messages.success_msg()
     print(msg)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -24,6 +24,8 @@ def main():
     # If --exception-type not specified, choose one.
     if not pb_config.exception_type:
         pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
+    print(pb_config.exception_type)
+    print("\nHERE")
 
     # Currently, handles just one exception type per call.
     # When multiple are supported, implement more complex logic for choosing which ones

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -31,15 +31,18 @@ def main():
     # When multiple are supported, implement more complex logic for choosing which ones
     # to introduce, and tracking bugs. Also consider a more appropriate dispatch approach
     # as the project evolves.
-    if pb_config.exception_type == "ModuleNotFoundError":
-        new_bugs_made = buggers.module_not_found_bugger(py_files)
-        bugs_added += new_bugs_made
-    elif pb_config.exception_type == "AttributeError":
-        new_bugs_made = buggers.attribute_error_bugger(py_files)
-        bugs_added += new_bugs_made
-    elif pb_config.exception_type == "IndentationError":
-        new_bugs_made = buggers.indentation_error_bugger(py_files)
-        bugs_added += new_bugs_made
+    for _ in range(pb_config.num_bugs):
+        if pb_config.exception_type == "ModuleNotFoundError":
+            # new_bugs_made = buggers.module_not_found_bugger(py_files)
+            # bugs_added += new_bugs_made
+            if buggers.module_not_found_bugger(py_files):
+                bugs_added += 1
+        elif pb_config.exception_type == "AttributeError":
+            new_bugs_made = buggers.attribute_error_bugger(py_files)
+            bugs_added += new_bugs_made
+        elif pb_config.exception_type == "IndentationError":
+            new_bugs_made = buggers.indentation_error_bugger(py_files)
+            bugs_added += new_bugs_made
 
     # Show a final success/fail message.
     msg = cli_messages.success_msg(bugs_added, pb_config.num_bugs)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -20,6 +20,11 @@ def main():
     # Track how many bugs have been added.
     bugs_added = 0
 
+    # If --exception-type not specified, choose one.
+    supported_exceptions = ["ModuleNotFoundError", "AttributeError", "IndentationError"]
+    if not pb_config.exception_type:
+        pb_config.exception_type = random.choice(supported_exceptions)
+
     # Currently, handles just one exception type per call.
     # When multiple are supported, implement more complex logic for choosing which ones
     # to introduce, and tracking bugs. Also consider a more appropriate dispatch approach

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -33,13 +33,9 @@ def main():
     # as the project evolves.
     for _ in range(pb_config.num_bugs):
         if pb_config.exception_type == "ModuleNotFoundError":
-            # new_bugs_made = buggers.module_not_found_bugger(py_files)
-            # bugs_added += new_bugs_made
             if buggers.module_not_found_bugger(py_files):
                 bugs_added += 1
         elif pb_config.exception_type == "AttributeError":
-            # new_bugs_made = buggers.attribute_error_bugger(py_files)
-            # bugs_added += new_bugs_made
             if buggers.attribute_error_bugger(py_files):
                 bugs_added += 1
         elif pb_config.exception_type == "IndentationError":

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -39,8 +39,10 @@ def main():
             if buggers.attribute_error_bugger(py_files):
                 bugs_added += 1
         elif pb_config.exception_type == "IndentationError":
-            new_bugs_made = buggers.indentation_error_bugger(py_files)
-            bugs_added += new_bugs_made
+            # new_bugs_made = buggers.indentation_error_bugger(py_files)
+            # bugs_added += new_bugs_made
+            if buggers.indentation_error_bugger(py_files):
+                bugs_added += 1
 
     # Show a final success/fail message.
     msg = cli_messages.success_msg(bugs_added, pb_config.num_bugs)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -5,6 +5,7 @@ from py_bugger import buggers
 from py_bugger.utils import file_utils
 
 from py_bugger.cli.config import pb_config
+from py_bugger.cli.config import SUPPORTED_EXCEPTION_TYPES
 from py_bugger.cli import cli_messages
 
 
@@ -21,9 +22,8 @@ def main():
     bugs_added = 0
 
     # If --exception-type not specified, choose one.
-    supported_exceptions = ["ModuleNotFoundError", "AttributeError", "IndentationError"]
     if not pb_config.exception_type:
-        pb_config.exception_type = random.choice(supported_exceptions)
+        pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
 
     # Currently, handles just one exception type per call.
     # When multiple are supported, implement more complex logic for choosing which ones

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -3,6 +3,7 @@ import random
 
 from py_bugger import buggers
 from py_bugger.utils import file_utils
+from py_bugger.utils.modification import modifications
 
 from py_bugger.cli.config import pb_config
 from py_bugger.cli.config import SUPPORTED_EXCEPTION_TYPES
@@ -18,28 +19,24 @@ def main():
     # Get a list of .py files we can consider modifying.
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 
-    # Track how many bugs have been added.
-    bugs_added = 0
-
     # If --exception-type not specified, choose one.
     if not pb_config.exception_type:
         pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
 
-    # Currently, handles just one exception type per call.
+    # Currently, handles just one exception type per py-bugger call.
     # When multiple are supported, implement more complex logic for choosing which ones
     # to introduce, and tracking bugs. Also consider a more appropriate dispatch approach
     # as the project evolves.
     for _ in range(pb_config.num_bugs):
         if pb_config.exception_type == "ModuleNotFoundError":
-            if buggers.module_not_found_bugger(py_files):
-                bugs_added += 1
+            buggers.module_not_found_bugger(py_files)
         elif pb_config.exception_type == "AttributeError":
-            if buggers.attribute_error_bugger(py_files):
-                bugs_added += 1
+            buggers.attribute_error_bugger(py_files)
         elif pb_config.exception_type == "IndentationError":
-            if buggers.indentation_error_bugger(py_files):
-                bugs_added += 1
+            buggers.indentation_error_bugger(py_files)
 
     # Show a final success/fail message.
+    bugs_added = len(modifications)
     msg = cli_messages.success_msg(bugs_added, pb_config.num_bugs)
+    # msg = cli_messags.succes_msg()
     print(msg)

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -39,8 +39,6 @@ def main():
             if buggers.attribute_error_bugger(py_files):
                 bugs_added += 1
         elif pb_config.exception_type == "IndentationError":
-            # new_bugs_made = buggers.indentation_error_bugger(py_files)
-            # bugs_added += new_bugs_made
             if buggers.indentation_error_bugger(py_files):
                 bugs_added += 1
 

--- a/src/py_bugger/utils/bug_utils.py
+++ b/src/py_bugger/utils/bug_utils.py
@@ -4,6 +4,7 @@ import random
 import builtins
 
 from py_bugger.utils import file_utils
+from py_bugger.utils.modification import Modification, modifications
 
 
 def make_typo(name):
@@ -69,9 +70,13 @@ def add_indentation(path, target_line):
         # `line` contains leading whitespace and trailing newline.
         # `target_line` just contains code, so use `in` rather than `==`.
         if target_line in line:
-            line = f"    {line}"
-            modified_lines.append(line)
+            modified_line = f"    {line}"
+            modified_lines.append(modified_line)
             indentation_added = True
+
+            # Record this modification.
+            modification = Modification(path, original_line=line, modified_line=modified_line)
+            modifications.append(modification)
         else:
             modified_lines.append(line)
 

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -62,8 +62,6 @@ class ImportModifier(cst.CSTTransformer):
             new_names = [cst.ImportAlias(name=cst.Name(new_name))]
 
             # Record this modification.
-            # DEV: modified node needs to be generated using new_names. Set breakpoint here to verify the modification
-            # is stored correctly.
             modified_node = updated_node.with_changes(names=new_names)
             modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
             modifications.append(modification)
@@ -76,7 +74,7 @@ class ImportModifier(cst.CSTTransformer):
 class AttributeModifier(cst.CSTTransformer):
     """Modify attributes in the user's project."""
 
-    def __init__(self, node_to_break, node_index):
+    def __init__(self, node_to_break, node_index, path):
         self.node_to_break = node_to_break
 
         # There may be identical nodes in the tree. node_index determines which to modify.
@@ -86,6 +84,9 @@ class AttributeModifier(cst.CSTTransformer):
         # Each use of this class should only generate one bug. But multiple nodes
         # can match node_to_break, so make sure we only modify one node.
         self.bug_generated = False
+
+        # Need this to record the modification we're making.
+        self.path = path
 
     def leave_Attribute(self, original_node, updated_node):
         """Modify an attribute name, to generate AttributeError."""
@@ -105,6 +106,11 @@ class AttributeModifier(cst.CSTTransformer):
 
             # Modify the node name.
             new_attr = cst.Name(new_identifier)
+
+            # Record this modification.
+            modified_node = updated_node.with_changes(attr=new_attr)
+            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
+            modifications.append(modification)
 
             self.bug_generated = True
 

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -3,6 +3,7 @@
 import libcst as cst
 
 from py_bugger.utils import bug_utils
+from py_bugger.utils.modification import Modification, modifications
 
 
 class NodeCollector(cst.CSTVisitor):
@@ -41,8 +42,11 @@ class ImportModifier(cst.CSTTransformer):
     tree.
     """
 
-    def __init__(self, node_to_break):
+    def __init__(self, node_to_break, path):
         self.node_to_break = node_to_break
+
+        # Need this to record the modification we're making.
+        self.path = path
 
     def leave_Import(self, original_node, updated_node):
         """Modify a direct `import <package>` statement."""
@@ -56,6 +60,10 @@ class ImportModifier(cst.CSTTransformer):
 
             # Modify the node name.
             new_names = [cst.ImportAlias(name=cst.Name(new_name))]
+
+            # Record this modification.
+            modification = Modification(path=self.path, original_node=original_node, modified_node=updated_node)
+            modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)
 

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -62,7 +62,10 @@ class ImportModifier(cst.CSTTransformer):
             new_names = [cst.ImportAlias(name=cst.Name(new_name))]
 
             # Record this modification.
-            modification = Modification(path=self.path, original_node=original_node, modified_node=updated_node)
+            # DEV: modified node needs to be generated using new_names. Set breakpoint here to verify the modification
+            # is stored correctly.
+            modified_node = updated_node.with_changes(names=new_names)
+            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
             modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -3,7 +3,7 @@
 import subprocess
 import shlex
 from pathlib import Path
-import pys
+import sys
 
 from py_bugger.utils.modification import modifications
 

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -37,7 +37,7 @@ def get_paths_lines(py_files, targets):
 
     return paths_lines
 
-def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=None):
+def check_unmodified(candidate_path, candidate_node=None, candidate_line=None):
     """Check if it's safe to modify a node or line.
 
     If the node or line has not already been modified, return True. Otherwise,

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -33,7 +33,7 @@ def get_paths_lines(py_files, targets):
     for path in py_files:
         lines = path.read_text().splitlines()
         _remove_modified_lines(path, lines)
-        
+
         for line in lines:
             stripped_line = line.strip()
             if any([stripped_line.startswith(target) for target in targets]):
@@ -73,7 +73,7 @@ def check_unmodified(candidate_path, candidate_node=None, candidate_line=None):
 
 def _get_py_files_git(target_dir):
     """Get all relevant .py files from a directory managed by Git."""
-    cmd = f'git -C {target_dir} ls-files "*.py"'
+    cmd = f'git -C {target_dir.as_posix()} ls-files "*.py"'
     cmd_parts = shlex.split(cmd)
     output = subprocess.run(cmd_parts, capture_output=True)
     py_files = output.stdout.decode().strip().splitlines()

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -86,8 +86,11 @@ def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=Non
     modified_nodes = [m.modified_node for m in relevant_modifications]
     modified_lines = [m.modified_line for m in relevant_modifications]
 
-    if candidate_node in modified_nodes:
-        return False
+    # Need to use deep_equals for node comparisons.
+    for modified_node in modified_nodes:
+        if modified_node.deep_equals(candidate_node):
+            return False
+
     if candidate_line in modified_lines:
         return False
 

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -100,7 +100,7 @@ def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=Non
 
 def _get_py_files_git(target_dir):
     """Get all relevant .py files from a directory manage.py by Git."""
-    cmd = 'git ls-files "*.py"'
+    cmd = f'git -C {target_dir} ls-files "*.py"'
     cmd_parts = shlex.split(cmd)
     output = subprocess.run(cmd_parts, capture_output=True)
     py_files = output.stdout.decode().strip().splitlines()

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -26,10 +26,13 @@ def get_py_files(target_dir, target_file):
 
 
 def get_paths_lines(py_files, targets):
-    """Get all lines from all files matching targets."""
+    """Get all lines from all files matching targets, if they haven't already
+    been modified.
+    """
     paths_lines = []
     for path in py_files:
         lines = path.read_text().splitlines()
+        _remove_modified_lines(path, lines)
         for line in lines:
             stripped_line = line.strip()
             if any([stripped_line.startswith(target) for target in targets]):
@@ -110,3 +113,24 @@ def _get_py_files_non_git(target_dir):
     py_files = [pf for pf in py_files if not pf.name.startswith("test_")]
 
     return py_files
+
+def _remove_modified_lines(path, lines):
+    """Remove lines from the list that have already been modified."""
+    print("IN REMOVE MODIFIED LINES")
+    # breakpoint()
+    for modification in modifications:
+        if modification.path != path:
+            continue
+        if not modification.modified_line:
+            continue
+
+        # This path has been modified. Check line.
+        modified_line = modification.modified_line.rstrip()
+        if modified_line in lines:
+            print("HERE HERE HERE")
+            # DEV: We may want to look at line numbers. For now, remove all occurrences 
+            # of this line.
+            # lines.remove(modified_line)
+            while modified_line in lines:
+                lines.remove(modified_line)
+    # breakpoint()

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -3,7 +3,9 @@
 import subprocess
 import shlex
 from pathlib import Path
-import sys
+import pys
+
+from py_bugger.utils.modification import modifications
 
 
 # --- Public functions ---
@@ -34,6 +36,63 @@ def get_paths_lines(py_files, targets):
                 paths_lines.append((path, line))
 
     return paths_lines
+
+def already_used(candidate_path, candidate_node=None, candidate_line=None):
+    """Check if a node or line has already been modifed."""
+    # If this path hasn't been modified at all, return False.
+    # if candidate_path not in [m.path for m in modifications]:
+    #     return False
+
+    # # This path has been modified. Check the nodes/ lines.
+    # modified_nodes = [m.node for m in modifications if ]
+
+
+    # for modification in modifications:
+    #     if candidate_path != modification.path:
+    #         return False
+
+
+
+    # Only look at modifications in the candidate path.
+    # relevant_modifications = [m if m.path == candidate_path for m in modifications]
+    relevant_modifications = [m for m in modifications if m.path == candidate_path]
+
+    if not relevant_modifications:
+        return False
+
+    modified_nodes = [m.modified_node for m in relevant_modifications]
+    modified_lines = [m.modified_line for m in relevant_modifications]
+
+    if candidate_node in modified_nodes:
+        return True
+    if candidate_line in modified_lines:
+        return True
+
+    # The candidate node or line has not been modified during this run of py-bugger.
+    return False
+
+def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=None):
+    """Check if it's safe to modify a node or line.
+
+    If the node or line has not already been modified, return True. Otherwise,
+    return False.
+    """
+    # Only look at modifications in the candidate path.
+    relevant_modifications = [m for m in modifications if m.path == candidate_path]
+
+    if not relevant_modifications:
+        return True
+
+    modified_nodes = [m.modified_node for m in relevant_modifications]
+    modified_lines = [m.modified_line for m in relevant_modifications]
+
+    if candidate_node in modified_nodes:
+        return False
+    if candidate_line in modified_lines:
+        return False
+
+    # The candidate node or line has not been modified during this run of py-bugger.
+    return True
 
 
 # --- Helper functions ---

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -99,7 +99,7 @@ def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=Non
 
 
 def _get_py_files_git(target_dir):
-    """Get all relevant .py files from a directory manage.py by Git."""
+    """Get all relevant .py files from a directory managed by Git."""
     cmd = f'git -C {target_dir} ls-files "*.py"'
     cmd_parts = shlex.split(cmd)
     output = subprocess.run(cmd_parts, capture_output=True)
@@ -112,6 +112,9 @@ def _get_py_files_git(target_dir):
     py_files = [pf for pf in py_files if "test_code/" not in pf.as_posix()]
     py_files = [pf for pf in py_files if pf.name != "conftest.py"]
     py_files = [pf for pf in py_files if not pf.name.startswith("test_")]
+
+    # Build full paths.
+    py_files = [target_dir / pf for pf in py_files]
 
     return py_files
 

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -37,40 +37,6 @@ def get_paths_lines(py_files, targets):
 
     return paths_lines
 
-def already_used(candidate_path, candidate_node=None, candidate_line=None):
-    """Check if a node or line has already been modifed."""
-    # If this path hasn't been modified at all, return False.
-    # if candidate_path not in [m.path for m in modifications]:
-    #     return False
-
-    # # This path has been modified. Check the nodes/ lines.
-    # modified_nodes = [m.node for m in modifications if ]
-
-
-    # for modification in modifications:
-    #     if candidate_path != modification.path:
-    #         return False
-
-
-
-    # Only look at modifications in the candidate path.
-    # relevant_modifications = [m if m.path == candidate_path for m in modifications]
-    relevant_modifications = [m for m in modifications if m.path == candidate_path]
-
-    if not relevant_modifications:
-        return False
-
-    modified_nodes = [m.modified_node for m in relevant_modifications]
-    modified_lines = [m.modified_line for m in relevant_modifications]
-
-    if candidate_node in modified_nodes:
-        return True
-    if candidate_line in modified_lines:
-        return True
-
-    # The candidate node or line has not been modified during this run of py-bugger.
-    return False
-
 def node_line_unmodified(candidate_path, candidate_node=None, candidate_line=None):
     """Check if it's safe to modify a node or line.
 

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -33,6 +33,7 @@ def get_paths_lines(py_files, targets):
     for path in py_files:
         lines = path.read_text().splitlines()
         _remove_modified_lines(path, lines)
+        
         for line in lines:
             stripped_line = line.strip()
             if any([stripped_line.startswith(target) for target in targets]):
@@ -116,8 +117,6 @@ def _get_py_files_non_git(target_dir):
 
 def _remove_modified_lines(path, lines):
     """Remove lines from the list that have already been modified."""
-    print("IN REMOVE MODIFIED LINES")
-    # breakpoint()
     for modification in modifications:
         if modification.path != path:
             continue
@@ -127,10 +126,7 @@ def _remove_modified_lines(path, lines):
         # This path has been modified. Check line.
         modified_line = modification.modified_line.rstrip()
         if modified_line in lines:
-            print("HERE HERE HERE")
             # DEV: We may want to look at line numbers. For now, remove all occurrences 
             # of this line.
-            # lines.remove(modified_line)
             while modified_line in lines:
                 lines.remove(modified_line)
-    # breakpoint()

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -24,3 +24,37 @@ class Modification:
 
 # Only make one instance of this list.
 modifications = []
+
+
+# def already_used(candidate_path, candidate_node=None, candidate_line=None):
+#     """Check if a node or line has already been modifed."""
+#     # If this path hasn't been modified at all, return False.
+#     # if candidate_path not in [m.path for m in modifications]:
+#     #     return False
+
+#     # # This path has been modified. Check the nodes/ lines.
+#     # modified_nodes = [m.node for m in modifications if ]
+
+
+#     # for modification in modifications:
+#     #     if candidate_path != modification.path:
+#     #         return False
+
+
+
+#     # Only look at modifications in the candidate path.
+#     relevant_modifications = [m if m.path == candidate_path for m in modifications]
+
+#     if not relevant_modifications:
+#         return False
+
+#     modified_nodes = [m.modified_node for m in relevant_modifications]
+#     modified_lines = [m.modified_line for m in relevant_modifications]
+
+#     if candidate_node in modified_nodes:
+#         return True
+#     if candidate_line in modified_lines:
+#         return True
+
+#     # The candidate node or line has not been modified during this run of py-bugger.
+#     return False

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -1,0 +1,26 @@
+"""Model for modifications made to files to introduce bugs.
+
+This is used to track which modifications have been made, so we don't make multiple
+modifications to the same node or line.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import libcst as cst
+
+
+@dataclass
+class Modification:
+    path: Path = ""
+
+    # Only data for a line or node will be set, not both.
+    # DEV: For line, may want to store line number?
+    original_node: cst.CSTNode = None
+    modified_node: cst.CSTNode = None
+
+    original_line: str = ""
+    modified_line: str = ""
+
+# Only make one instance of this list.
+modifications = []

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -2,6 +2,10 @@
 
 This is used to track which modifications have been made, so we don't make multiple
 modifications to the same node or line.
+
+Not currently using original_node or original_line, but including these means
+the list of modifications can be used to stage all changes, and write them all at
+once if that becomes a better approach.
 """
 
 from dataclasses import dataclass
@@ -24,37 +28,3 @@ class Modification:
 
 # Only make one instance of this list.
 modifications = []
-
-
-# def already_used(candidate_path, candidate_node=None, candidate_line=None):
-#     """Check if a node or line has already been modifed."""
-#     # If this path hasn't been modified at all, return False.
-#     # if candidate_path not in [m.path for m in modifications]:
-#     #     return False
-
-#     # # This path has been modified. Check the nodes/ lines.
-#     # modified_nodes = [m.node for m in modifications if ]
-
-
-#     # for modification in modifications:
-#     #     if candidate_path != modification.path:
-#     #         return False
-
-
-
-#     # Only look at modifications in the candidate path.
-#     relevant_modifications = [m if m.path == candidate_path for m in modifications]
-
-#     if not relevant_modifications:
-#         return False
-
-#     modified_nodes = [m.modified_node for m in relevant_modifications]
-#     modified_lines = [m.modified_line for m in relevant_modifications]
-
-#     if candidate_node in modified_nodes:
-#         return True
-#     if candidate_line in modified_lines:
-#         return True
-
-#     # The candidate node or line has not been modified during this run of py-bugger.
-#     return False

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -258,15 +258,16 @@ def test_random_py_file_affected(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst_ten_imports.as_posix()}"
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst_system_info.as_posix()}"
     cmd_parts = shlex.split(cmd)
-    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    stderr = subprocess.run(cmd_parts, capture_output=True, text=True).stderr
+
     assert "Traceback (most recent call last)" in stderr
-    assert 'ten_imports.py", line ' in stderr
+    assert 'system_info_script.py", line ' in stderr
     assert "ModuleNotFoundError: No module named " in stderr
 
     # Other file should not be changed.
-    assert filecmp.cmp(e2e_config.path_system_info, path_dst_system_info)
+    assert filecmp.cmp(e2e_config.path_ten_imports, path_dst_ten_imports)
 
 
 def test_unable_insert_all_bugs(tmp_path_factory, e2e_config):

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -46,6 +46,7 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    print(f"cmd: {cmd}")
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
     print(stdout)

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -295,7 +295,7 @@ def test_random_py_file_affected(tmp_path_factory, e2e_config):
 
     # Run file, should raise ModuleNotFoundError.
     # When we collect files, the order is different on different OSes.
-    if platform.system() == "Windows":
+    if platform.system() in ["Windows", "Linux"]:
         path_modified = path_dst_ten_imports
         path_unmodified = path_dst_system_info
         path_unmodified_original = e2e_config.path_system_info

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -106,6 +106,7 @@ def test_modulenotfounderror(tmp_path_factory, e2e_config):
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    print(f"cmd: {cmd}")
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
 
@@ -285,6 +286,7 @@ def test_unable_insert_all_bugs(tmp_path_factory, e2e_config, exception_type):
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type {exception_type} -n 5 --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    print(f"cmd: {cmd}")
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -17,32 +17,6 @@ import pytest
 
 # --- Test functions ---
 
-
-def test_no_exception_type(tmp_path_factory, e2e_config):
-    """Test output for not passing --exception-type."""
-
-    # Copy sample code to tmp dir.
-    tmp_path = tmp_path_factory.mktemp("sample_code")
-    print(f"\nCopying code to: {tmp_path.as_posix()}")
-
-    path_dst = tmp_path / e2e_config.path_name_picker.name
-    shutil.copyfile(e2e_config.path_name_picker, path_dst)
-
-    # Make bare py-bugger call.
-    cmd = f"py-bugger"
-    cmd_parts = shlex.split(cmd)
-    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
-
-    # Verify output.
-    assert (
-        "You must be explicit about what kinds of errors you want to induce in the project."
-        in stdout
-    )
-
-    # Check that .py file is unchanged.
-    assert filecmp.cmp(e2e_config.path_name_picker, path_dst)
-
-
 def test_help(e2e_config):
     """Test output of `py-bugger --help`."""
     # Set an explicit column width, so output is consistent across systems.
@@ -59,9 +33,8 @@ def test_help(e2e_config):
     )
 
 
-def test_no_exception_type_new(tmp_path_factory, e2e_config):
+def test_no_exception_type(tmp_path_factory, e2e_config):
     """Test that passing no -e arg chooses a random exception type to induce."""
-    # DEV: Remove old test, rename this test.
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
@@ -78,13 +51,12 @@ def test_no_exception_type_new(tmp_path_factory, e2e_config):
 
     assert "All requested bugs inserted." in stdout
 
-    # Run file, should raise ModuleNotFoundError.
-    # cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
-    # cmd_parts = shlex.split(cmd)
-    # stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
-    # assert "Traceback (most recent call last)" in stderr
-    # assert 'name_picker.py", line 1, in <module>' in stderr
-    # assert "ModuleNotFoundError: No module named" in stderr
+    # Run file, should raise IndentationError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert 'dog_bark.py", line 12' in stderr
+    assert "IndentationError: unexpected indent" in stderr
 
 
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -285,7 +285,7 @@ def test_unable_insert_all_bugs(tmp_path_factory, e2e_config, exception_type):
     shutil.copyfile(path_src, path_dst)
 
     # Run py-bugger against directory.
-    cmd = f"py-bugger --exception-type {exception_type} -n 5 --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    cmd = f"py-bugger --exception-type {exception_type} -n 10 --target-dir {tmp_path.as_posix()} --ignore-git-status"
     print(f"cmd: {cmd}")
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -59,6 +59,35 @@ def test_help(e2e_config):
     )
 
 
+def test_no_exception_type_new(tmp_path_factory, e2e_config):
+    """Test that passing no -e arg chooses a random exception type to induce."""
+    # DEV: Remove old test, rename this test.
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = e2e_config.path_sample_scripts / "dog_bark.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    cmd_parts = shlex.split(cmd)
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+
+    assert "All requested bugs inserted." in stdout
+
+    # Run file, should raise ModuleNotFoundError.
+    # cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    # cmd_parts = shlex.split(cmd)
+    # stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    # assert "Traceback (most recent call last)" in stderr
+    # assert 'name_picker.py", line 1, in <module>' in stderr
+    # assert "ModuleNotFoundError: No module named" in stderr
+
+
+
 def test_modulenotfounderror(tmp_path_factory, e2e_config):
     """py-bugger --exception-type ModuleNotFoundError"""
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -60,6 +60,7 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
     assert "IndentationError: unexpected indent" in stderr
 
 
+@pytest.mark.skip()
 def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
     """Test that passing no -e arg induces an exception, even when the first 
     exception type randomly selected is not possible.
@@ -166,6 +167,7 @@ def test_two_bugs(tmp_path_factory, e2e_config):
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --num-bugs 2 --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    print(f"cmd: {cmd}")
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -48,6 +48,39 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
     cmd = f"py-bugger --target-dir {tmp_path.as_posix()} --ignore-git-status"
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+    print(stdout)
+
+    assert "All requested bugs inserted." in stdout
+
+    # Run file, should raise IndentationError.
+    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd_parts = shlex.split(cmd)
+    stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
+    assert 'dog_bark.py", line 12' in stderr
+    assert "IndentationError: unexpected indent" in stderr
+
+
+def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
+    """Test that passing no -e arg induces an exception, even when the first 
+    exception type randomly selected is not possible.
+    """
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    # The first exception type chosen it will attempt is IndentationError.
+    # This sample script has no indented blocks, so py-bugger will have to 
+    # find another exception to induce.
+    path_src = e2e_config.path_sample_scripts / "system_info_script.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Run py-bugger against directory.
+    cmd = f"py-bugger --target-dir {tmp_path.as_posix()} --ignore-git-status"
+    cmd_parts = shlex.split(cmd)
+    stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
+    print(stdout)
 
     assert "All requested bugs inserted." in stdout
 

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -182,9 +182,11 @@ def test_two_bugs(tmp_path_factory, e2e_config):
     assert "ModuleNotFoundError: No module named " in stderr
 
     # Read modified file; should have changed both import statements.
-    modified_source = path_dst.read_text()
-    assert "import sys" not in modified_source
-    assert "import os" not in modified_source
+    # Note that `import os` can become `import osp`, so we can't just do:
+    #     assert "import os" not in modified_source
+    lines = path_dst.read_text().splitlines()
+    assert "import sys" not in lines
+    assert "import os" not in lines
 
 
 def test_random_import_affected(tmp_path_factory, e2e_config):

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -291,7 +291,7 @@ def test_unable_insert_all_bugs(tmp_path_factory, e2e_config, exception_type):
     stdout = subprocess.run(cmd_parts, capture_output=True).stdout.decode()
 
     # Check that at least one bug was inserted, but unable to introduce all requested.
-    assert "Inserted " in stdout
+    assert "Added bug." in stdout
     assert "Unable to introduce additional bugs of the requested type." in stdout
 
 

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -47,11 +47,8 @@ def test_preserve_file_ending_trailing_newline(
 
     # Check that last line has a trailing newline.
     lines = path_dst.read_text().splitlines(keepends=True)
-    if exception_type == "AttributeError":
-        # Random seed causes a bug in the last line, but we're just checking the line ending.
-        assert lines[-1] == "dog.sayhi()\n"
-    else:
-        assert lines[-1] == "dog.say_hi()\n"
+
+    assert lines[-1] == "dog.say_hi()\n"
 
 
 @pytest.mark.parametrize(
@@ -81,11 +78,8 @@ def test_preserve_file_ending_no_trailing_newline(
 
     # Check that last line is not blank.
     lines = path_dst.read_text().splitlines(keepends=True)
-    if exception_type == "AttributeError":
-        # Random seed causes a bug in the last line, but we're just checking the line ending.
-        assert lines[-1] == "dog.sayhi()"
-    else:
-        assert lines[-1] == "dog.say_hi()"
+    
+    assert lines[-1] == "dog.say_hi()"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,0 +1,5 @@
+"""Config for integration tests.
+
+Any test that's more than a unit test, but doesn't require running py-bugger against
+actual code should probably be an integration test.
+"""

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -15,18 +15,20 @@ from py_bugger.cli import cli_messages
 
 
 @pytest.mark.parametrize(
-    "exception_type", ["IndentationErrorr", "AttributeErrorr", "ModuleNotFoundErrorr"]
+    "actual_expected", [("IndentationErrorr", "IndentationError"), ("AttributeErrorr", "AttributeError"), ("ModuleNotFoundErrorr", "ModuleNotFoundError")]
 )
-def test_exception_type_typo(exception_type):
+def test_exception_type_typo(actual_expected):
     """Test appropriate handling of a typo in the exception type."""
     # Run py-bugger against file.
+    exception_type, correction = actual_expected
     cmd = f"py-bugger --exception-type {exception_type} --target-file nonexistent_python_file.py --ignore-git-status"
     print("cmd:", cmd)
     cmd_parts = shlex.split(cmd)
 
     stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
 
-    assert f"You specified {exception_type} for --exception-type. Did you mean" in stdout
+    msg_expected = cli_messages.msg_apparent_typo(exception_type, correction)
+    assert msg_expected in stdout
 
 # def test_exception_type_unsupported():
 #     """Test appropriate handling of an unsupported exception type."""

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -26,4 +26,15 @@ def test_exception_type_typo(exception_type):
 
     stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
 
-    assert "Did you mean" in stdout
+    assert f"You specified {exception_type} for --exception-type. Did you mean" in stdout
+
+# def test_exception_type_unsupported():
+#     """Test appropriate handling of an unsupported exception type."""
+#     # Run py-bugger against file.
+#     cmd = f"py-bugger --exception-type CompletelyUnsupportedExceptionType --target-file nonexistent_python_file.py --ignore-git-status"
+#     print("cmd:", cmd)
+#     cmd_parts = shlex.split(cmd)
+
+#     stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
+
+#     assert "Did you mean" in stdout

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -1,0 +1,29 @@
+"""Tests that focus on the CLI itself."""
+
+import shutil
+import shlex
+import subprocess
+import filecmp
+import os
+import sys
+import platform
+from pathlib import Path
+
+import pytest
+
+from py_bugger.cli import cli_messages
+
+
+@pytest.mark.parametrize(
+    "exception_type", ["IndentationErrorr", "AttributeErrorr", "ModuleNotFoundErrorr"]
+)
+def test_exception_type_typo(exception_type):
+    """Test appropriate handling of a typo in the exception type."""
+    # Run py-bugger against file.
+    cmd = f"py-bugger --exception-type {exception_type} --target-file nonexistent_python_file.py --ignore-git-status"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
+
+    stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
+
+    assert "Did you mean" in stdout

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -30,13 +30,15 @@ def test_exception_type_typo(actual_expected):
     msg_expected = cli_messages.msg_apparent_typo(exception_type, correction)
     assert msg_expected in stdout
 
-# def test_exception_type_unsupported():
-#     """Test appropriate handling of an unsupported exception type."""
-#     # Run py-bugger against file.
-#     cmd = f"py-bugger --exception-type CompletelyUnsupportedExceptionType --target-file nonexistent_python_file.py --ignore-git-status"
-#     print("cmd:", cmd)
-#     cmd_parts = shlex.split(cmd)
+def test_exception_type_unsupported():
+    """Test appropriate handling of an unsupported exception type."""
+    # Run py-bugger against file.
+    exception_type = "CompletelyUnsupportedExceptionType"
+    cmd = f"py-bugger --exception-type {exception_type} --target-file nonexistent_python_file.py --ignore-git-status"
+    print("cmd:", cmd)
+    cmd_parts = shlex.split(cmd)
 
-#     stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
+    stdout = subprocess.run(cmd_parts, capture_output=True, text=True).stdout
 
-#     assert "Did you mean" in stdout
+    msg_expected = cli_messages.msg_unsupported_exception_type(exception_type)
+    assert msg_expected in stdout


### PR DESCRIPTION
The `-e` arg is now optional. If it's omitted, an exception type to induce is chosen randomly.

Also:
- Makes suggestions when a typo is detected in `-e` args.
- Fixes bug related to running py-bugger from a Git repo, against another target directory with its own Git repo.
- Cleans up some internals; see Changeling 0.4.1 entry for more details. Most notably, tracks each bug as it's introduced.