### PR TITLE
Ensure CST-based parsing happens before regex-based parsing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
 
           # Run all tests
           source .venv/bin/activate
-          pytest -x
+          pytest -x -n auto
 
       - name: Run Windows tests
 
@@ -77,4 +77,4 @@ jobs:
           git config --global init.defaultBranch main
 
           # Run all tests
-          pytest -x
+          pytest -x -n auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Changelog: python-bugger
 
 Looks for a clean Git status before introducing bugs.
 
+### Unreleased
+
+#### External changes
+
+- NA
+
+#### Internal changes
+
+- Main loop works from a list of bugs to introduce, rather than ranging over `num_bugs`.
+
 ### 0.4.1
 
 #### External changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ Looks for a clean Git status before introducing bugs.
 
 #### External changes
 
-- NA
+- When no `-e` arg is passed, generates a random sequence of bugs to induce.
 
 #### Internal changes
 
 - Main loop works from a list of bugs to introduce, rather than ranging over `num_bugs`.
+- Reorders `requested_bugs` so CST-based parsing happens before regex-based parsing. Avoids writing syntax-related bugs before parsing nodes.
+- Started integration tests that should take the place of many current e2e tests. Calls `py_bugger.main()` directly, and checks `requested_bugs` and `modfications`.
+- `Modification` objects record the exception type that's induced.
 
 ### 0.4.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dev = [
     "black>=24.1.0",
     "build>=1.2.1",
     "pytest>=8.3.0",
+    "pytest-xdist>=3.7.0",
     "twine>=5.1.1",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 colorama==0.4.6
 docutils==0.21.2
+execnet==2.1.1
 ghp-import==2.1.0
 id==1.5.0
 idna==3.10
@@ -38,6 +39,7 @@ pygments==2.19.1
 pymdown-extensions==10.14.3
 pyproject-hooks==1.2.0
 pytest==8.3.5
+pytest-xdist==3.7.0
 python-dateutil==2.9.0.post0
 pyyaml==6.0.2
 pyyaml-env-tag==0.1

--- a/src/py_bugger/buggers.py
+++ b/src/py_bugger/buggers.py
@@ -132,9 +132,10 @@ def _report_bug_added(path_modified):
     else:
         print(f"Added bug.")
 
+
 def _get_random_node(py_files, node_type):
     """Randomly select a node to modify.
-    
+
     Make sure it's a node that hasn't already been modified.
 
     Returns:

--- a/src/py_bugger/cli/cli.py
+++ b/src/py_bugger/cli/cli.py
@@ -48,4 +48,5 @@ def cli(**kwargs):
     # Importing py_bugger here cuts test time significantly, as these resources are not
     # loaded for many calls. (6.7s -> 5.4s, for 20% speedup, 6/10/25.)
     from py_bugger import py_bugger
+
     py_bugger.main()

--- a/src/py_bugger/cli/cli_messages.py
+++ b/src/py_bugger/cli/cli_messages.py
@@ -29,11 +29,13 @@ def success_msg():
         msg += "\nUnable to introduce additional bugs of the requested type."
         return msg
 
+
 # Validation for exception type.
 def msg_apparent_typo(actual, expected):
     """Suggest a typo fix for an exception type."""
     msg = f"You specified {actual} for --exception-type. Did you mean {expected}?"
     return msg
+
 
 def msg_unsupported_exception_type(exception_type):
     """Specified an unsupported exception type."""
@@ -99,4 +101,3 @@ def msg_git_not_used(pb_config):
 
     msg = f"The {target} you're running py-bugger against does not seem to be under version control. It's highly recommended that you run py-bugger against a file or project with a clean Git status. You can ignore this check with the --ignore-git-status argument."
     return msg
-

--- a/src/py_bugger/cli/cli_utils.py
+++ b/src/py_bugger/cli/cli_utils.py
@@ -66,7 +66,9 @@ def _validate_exception_type():
         return
 
     # Check for typos.
-    matches = difflib.get_close_matches(pb_config.exception_type, SUPPORTED_EXCEPTION_TYPES, n=1)
+    matches = difflib.get_close_matches(
+        pb_config.exception_type, SUPPORTED_EXCEPTION_TYPES, n=1
+    )
     if matches:
         msg = cli_messages.msg_apparent_typo(pb_config.exception_type, matches[0])
         click.echo(msg)
@@ -76,7 +78,6 @@ def _validate_exception_type():
     msg = cli_messages.msg_unsupported_exception_type(pb_config.exception_type)
     click.echo(msg)
     sys.exit()
-
 
 
 def _validate_target_dir():

--- a/src/py_bugger/cli/config.py
+++ b/src/py_bugger/cli/config.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-SUPPORTED_EXCEPTION_TYPES = ["ModuleNotFoundError", "AttributeError", "IndentationError"]
+SUPPORTED_EXCEPTION_TYPES = [
+    "ModuleNotFoundError",
+    "AttributeError",
+    "IndentationError",
+]
 
 
 @dataclass

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -9,12 +9,13 @@ from py_bugger.cli.config import SUPPORTED_EXCEPTION_TYPES
 from py_bugger.cli import cli_messages
 
 
-# Set a random seed when testing.
-if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
-    random.seed(int(seed))
 
 
 def main():
+    # Set a random seed when testing.
+    if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
+        random.seed(int(seed))
+        
     # Get a list of .py files we can consider modifying.
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -19,11 +19,17 @@ def main():
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 
     # If --exception-type not specified, choose one.
-    if not pb_config.exception_type:
-        pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
+    # if not pb_config.exception_type:
+        # pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
+        # Make a list of random supported exception types.
+        # requested_bugs = random.choices(SUPPORTED_EXCEPTION_TYPES, k=pb_config.num_bugs)
 
     # Make a list of requested bugs to work from.
-    requested_bugs = [pb_config.exception_type for _ in range(pb_config.num_bugs)]
+    if pb_config.exception_type:
+        requested_bugs = [pb_config.exception_type for _ in range(pb_config.num_bugs)]
+    else:
+        # No -e arg passed; get a random sequence of bugs to introduce.
+        requested_bugs = random.choices(SUPPORTED_EXCEPTION_TYPES, k=pb_config.num_bugs)
 
     # Currently, handles just one exception type per py-bugger call.
     # When multiple are supported, implement more complex logic for choosing which ones

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -9,13 +9,9 @@ from py_bugger.cli.config import SUPPORTED_EXCEPTION_TYPES
 from py_bugger.cli import cli_messages
 
 
-
-
 def main():
-    # Set a random seed when testing.
-    if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
-        random.seed(int(seed))
-        
+    set_random_seed()
+
     # Get a list of .py files we can consider modifying.
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 
@@ -45,3 +41,11 @@ def main():
 
     # Returning requested_bugs helps with testing.
     return requested_bugs
+
+
+# --- Helper functions ---
+
+def set_random_seed():
+    # Set a random seed when testing.
+    if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):
+        random.seed(int(seed))

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -22,16 +22,20 @@ def main():
     if not pb_config.exception_type:
         pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
 
+    # Make a list of requested bugs to work from.
+    requested_bugs = [pb_config.exception_type for _ in range(pb_config.num_bugs)]
+
     # Currently, handles just one exception type per py-bugger call.
     # When multiple are supported, implement more complex logic for choosing which ones
     # to introduce, and tracking bugs. Also consider a more appropriate dispatch approach
     # as the project evolves.
-    for _ in range(pb_config.num_bugs):
-        if pb_config.exception_type == "ModuleNotFoundError":
+    # for _ in range(pb_config.num_bugs):
+    for bug in requested_bugs:
+        if bug == "ModuleNotFoundError":
             buggers.module_not_found_bugger(py_files)
-        elif pb_config.exception_type == "AttributeError":
+        elif bug == "AttributeError":
             buggers.attribute_error_bugger(py_files)
-        elif pb_config.exception_type == "IndentationError":
+        elif bug == "IndentationError":
             buggers.indentation_error_bugger(py_files)
 
     # Show a final success/fail message.

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -45,6 +45,7 @@ def main():
 
 # --- Helper functions ---
 
+
 def set_random_seed():
     # Set a random seed when testing.
     if seed := os.environ.get("PY_BUGGER_RANDOM_SEED"):

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -24,7 +24,10 @@ def main():
         requested_bugs = [pb_config.exception_type for _ in range(pb_config.num_bugs)]
     else:
         # No -e arg passed; get a random sequence of bugs to introduce.
+        # Reorder sequence so all regex parsing happens after CST parsing. CST parsing
+        # will fail if it's attempted after introducing a bug that affects parsing.
         requested_bugs = random.choices(SUPPORTED_EXCEPTION_TYPES, k=pb_config.num_bugs)
+        requested_bugs = sorted(requested_bugs, key=lambda b: b == "IndentationError")
 
     # Introduce bugs, one at a time.
     for bug in requested_bugs:

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -43,5 +43,4 @@ def main():
     print(msg)
 
     # Returning requested_bugs helps with testing.
-    breakpoint()
     return requested_bugs

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -41,3 +41,7 @@ def main():
     # Show a final success/fail message.
     msg = cli_messages.success_msg()
     print(msg)
+
+    # Returning requested_bugs helps with testing.
+    breakpoint()
+    return requested_bugs

--- a/src/py_bugger/py_bugger.py
+++ b/src/py_bugger/py_bugger.py
@@ -18,24 +18,15 @@ def main():
     # Get a list of .py files we can consider modifying.
     py_files = file_utils.get_py_files(pb_config.target_dir, pb_config.target_file)
 
-    # If --exception-type not specified, choose one.
-    # if not pb_config.exception_type:
-        # pb_config.exception_type = random.choice(SUPPORTED_EXCEPTION_TYPES)
-        # Make a list of random supported exception types.
-        # requested_bugs = random.choices(SUPPORTED_EXCEPTION_TYPES, k=pb_config.num_bugs)
-
-    # Make a list of requested bugs to work from.
+    # Make a list of bugs to introduce.
     if pb_config.exception_type:
+        # User has requested a specific kind of bug.
         requested_bugs = [pb_config.exception_type for _ in range(pb_config.num_bugs)]
     else:
         # No -e arg passed; get a random sequence of bugs to introduce.
         requested_bugs = random.choices(SUPPORTED_EXCEPTION_TYPES, k=pb_config.num_bugs)
 
-    # Currently, handles just one exception type per py-bugger call.
-    # When multiple are supported, implement more complex logic for choosing which ones
-    # to introduce, and tracking bugs. Also consider a more appropriate dispatch approach
-    # as the project evolves.
-    # for _ in range(pb_config.num_bugs):
+    # Introduce bugs, one at a time.
     for bug in requested_bugs:
         if bug == "ModuleNotFoundError":
             buggers.module_not_found_bugger(py_files)

--- a/src/py_bugger/utils/bug_utils.py
+++ b/src/py_bugger/utils/bug_utils.py
@@ -75,7 +75,12 @@ def add_indentation(path, target_line):
             indentation_added = True
 
             # Record this modification.
-            modification = Modification(path, original_line=line, modified_line=modified_line)
+            modification = Modification(
+                path,
+                original_line=line,
+                modified_line=modified_line,
+                exception_induced=IndentationError,
+            )
             modifications.append(modification)
         else:
             modified_lines.append(line)

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -64,6 +64,7 @@ class ImportModifier(cst.CSTTransformer):
             # Record this modification.
             modified_node = updated_node.with_changes(names=new_names)
             modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
+            modification.exception_induced="ModuleNotFoundError"
             modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -63,8 +63,7 @@ class ImportModifier(cst.CSTTransformer):
 
             # Record this modification.
             modified_node = updated_node.with_changes(names=new_names)
-            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
-            modification.exception_induced="ModuleNotFoundError"
+            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node, exception_induced="ModuleNotFoundError")
             modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -63,7 +63,12 @@ class ImportModifier(cst.CSTTransformer):
 
             # Record this modification.
             modified_node = updated_node.with_changes(names=new_names)
-            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node, exception_induced=ModuleNotFoundError)
+            modification = Modification(
+                path=self.path,
+                original_node=original_node,
+                modified_node=modified_node,
+                exception_induced=ModuleNotFoundError,
+            )
             modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)
@@ -109,7 +114,9 @@ class AttributeModifier(cst.CSTTransformer):
 
             # Record this modification.
             modified_node = updated_node.with_changes(attr=new_attr)
-            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node)
+            modification = Modification(
+                path=self.path, original_node=original_node, modified_node=modified_node
+            )
             modifications.append(modification)
 
             self.bug_generated = True

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -63,7 +63,7 @@ class ImportModifier(cst.CSTTransformer):
 
             # Record this modification.
             modified_node = updated_node.with_changes(names=new_names)
-            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node, exception_induced="ModuleNotFoundError")
+            modification = Modification(path=self.path, original_node=original_node, modified_node=modified_node, exception_induced=ModuleNotFoundError)
             modifications.append(modification)
 
             return updated_node.with_changes(names=new_names)

--- a/src/py_bugger/utils/cst_utils.py
+++ b/src/py_bugger/utils/cst_utils.py
@@ -115,7 +115,10 @@ class AttributeModifier(cst.CSTTransformer):
             # Record this modification.
             modified_node = updated_node.with_changes(attr=new_attr)
             modification = Modification(
-                path=self.path, original_node=original_node, modified_node=modified_node
+                path=self.path,
+                original_node=original_node,
+                modified_node=modified_node,
+                exception_induced=AttributeError,
             )
             modifications.append(modification)
 

--- a/src/py_bugger/utils/file_utils.py
+++ b/src/py_bugger/utils/file_utils.py
@@ -41,6 +41,7 @@ def get_paths_lines(py_files, targets):
 
     return paths_lines
 
+
 def check_unmodified(candidate_path, candidate_node=None, candidate_line=None):
     """Check if it's safe to modify a node or line.
 
@@ -115,6 +116,7 @@ def _get_py_files_non_git(target_dir):
 
     return py_files
 
+
 def _remove_modified_lines(path, lines):
     """Remove lines from the list that have already been modified."""
     for modification in modifications:
@@ -126,7 +128,7 @@ def _remove_modified_lines(path, lines):
         # This path has been modified. Check line.
         modified_line = modification.modified_line.rstrip()
         if modified_line in lines:
-            # DEV: We may want to look at line numbers. For now, remove all occurrences 
+            # DEV: We may want to look at line numbers. For now, remove all occurrences
             # of this line.
             while modified_line in lines:
                 lines.remove(modified_line)

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -26,7 +26,7 @@ class Modification:
     original_line: str = ""
     modified_line: str = ""
 
-    exception_induced = None
+    exception_induced: str = ""
 
 # Only make one instance of this list.
 modifications = []

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -26,5 +26,7 @@ class Modification:
     original_line: str = ""
     modified_line: str = ""
 
+    exception_induced = None
+
 # Only make one instance of this list.
 modifications = []

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -8,8 +8,9 @@ the list of modifications can be used to stage all changes, and write them all a
 once if that becomes a better approach.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Type
 
 import libcst as cst
 
@@ -26,7 +27,7 @@ class Modification:
     original_line: str = ""
     modified_line: str = ""
 
-    exception_induced: str = ""
+    exception_induced: type[BaseException] = field(default=None)
 
 # Only make one instance of this list.
 modifications = []

--- a/src/py_bugger/utils/modification.py
+++ b/src/py_bugger/utils/modification.py
@@ -29,5 +29,6 @@ class Modification:
 
     exception_induced: type[BaseException] = field(default=None)
 
+
 # Only make one instance of this list.
 modifications = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,21 +8,32 @@ import pytest
 
 # --- Fixtures ---
 
+@pytest.fixture(autouse=True, scope="session")
+def set_random_seed_env():
+    """Make random selections repeatable."""
+    # To verify a random action, set autouse to False and run one test.
+    os.environ["PY_BUGGER_RANDOM_SEED"] = "10"
+
 @pytest.fixture(scope="session")
-def e2e_config():
+def on_windows():
+    """Some tests need to run differently on Windows."""
+    return platform.system() == "Windows"
+
+@pytest.fixture(scope="session")
+def test_config():
     """Resources useful to most tests."""
 
     class Config:
         # Paths
-        path_root = Path(__file__).parents[2]
+        path_root = Path(__file__).parents[1]
 
         path_tests = path_root / "tests"
-
         path_reference_files = path_tests / "e2e_tests" / "reference_files"
-
         path_sample_code = path_tests / "sample_code"
         path_sample_scripts = path_sample_code / "sample_scripts"
 
+        # Remove these. It's much cleaner to just build these scripts in each
+        # test function.
         path_name_picker = path_sample_scripts / "name_picker.py"
         path_system_info = path_sample_scripts / "system_info_script.py"
         path_ten_imports = path_sample_scripts / "ten_imports.py"
@@ -41,9 +52,3 @@ def e2e_config():
             python_cmd = path_root / ".venv" / "bin" / "python"
 
     return Config()
-
-
-@pytest.fixture(scope="session")
-def on_windows():
-    """Some tests need to run differently on Windows."""
-    return platform.system() == "Windows"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,16 +8,19 @@ import pytest
 
 # --- Fixtures ---
 
+
 @pytest.fixture(autouse=True, scope="session")
 def set_random_seed_env():
     """Make random selections repeatable."""
     # To verify a random action, set autouse to False and run one test.
     os.environ["PY_BUGGER_RANDOM_SEED"] = "10"
 
+
 @pytest.fixture(scope="session")
 def on_windows():
     """Some tests need to run differently on Windows."""
     return platform.system() == "Windows"
+
 
 @pytest.fixture(scope="session")
 def test_config():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import pytest
 
 # --- Fixtures ---
 
-
 @pytest.fixture(autouse=True, scope="session")
 def set_random_seed_env():
     """Make random selections repeatable."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 # --- Fixtures ---
 
+
 @pytest.fixture(autouse=True, scope="session")
 def set_random_seed_env():
     """Make random selections repeatable."""

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -8,14 +8,6 @@ import pytest
 
 # --- Fixtures ---
 
-
-@pytest.fixture(autouse=True, scope="session")
-def set_random_seed_env():
-    """Make random selections repeatable."""
-    # To verify a random action, set autouse to False and run one test.
-    os.environ["PY_BUGGER_RANDOM_SEED"] = "10"
-
-
 @pytest.fixture(scope="session")
 def e2e_config():
     """Resources useful to most tests."""

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -18,6 +18,7 @@ import pytest
 
 # --- Test functions ---
 
+
 def test_help(test_config):
     """Test output of `py-bugger --help`."""
     # Set an explicit column width, so output is consistent across systems.
@@ -61,6 +62,7 @@ def test_no_exception_type(tmp_path_factory, test_config):
 
     assert "AttributeError" in stderr
 
+
 @pytest.mark.parametrize("num_bugs", [2, 15])
 def test_no_exception_type_with_narg(tmp_path_factory, test_config, num_bugs):
     """Test that passing no -e arg works with --num-bugs."""
@@ -99,7 +101,7 @@ def test_no_exception_type_with_narg(tmp_path_factory, test_config, num_bugs):
 
 @pytest.mark.skip()
 def test_no_exception_type_first_not_possible(tmp_path_factory, test_config):
-    """Test that passing no -e arg induces an exception, even when the first 
+    """Test that passing no -e arg induces an exception, even when the first
     exception type randomly selected is not possible.
     """
 
@@ -108,7 +110,7 @@ def test_no_exception_type_first_not_possible(tmp_path_factory, test_config):
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
     # The first exception type chosen it will attempt is IndentationError.
-    # This sample script has no indented blocks, so py-bugger will have to 
+    # This sample script has no indented blocks, so py-bugger will have to
     # find another exception to induce.
     path_src = test_config.path_sample_scripts / "system_info_script.py"
     path_dst = tmp_path / path_src.name
@@ -128,7 +130,6 @@ def test_no_exception_type_first_not_possible(tmp_path_factory, test_config):
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert 'dog_bark.py", line 12' in stderr
     assert "IndentationError: unexpected indent" in stderr
-
 
 
 def test_modulenotfounderror(tmp_path_factory, test_config):
@@ -305,7 +306,7 @@ def test_random_py_file_affected(tmp_path_factory, test_config):
         path_modified = path_dst_system_info
         path_unmodified = path_dst_ten_imports
         path_unmodified_original = test_config.path_ten_imports
-    
+
     cmd = f"{test_config.python_cmd.as_posix()} {path_modified.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True, text=True).stderr
@@ -340,7 +341,6 @@ def test_unable_insert_all_bugs(tmp_path_factory, test_config, exception_type):
     # Check that at least one bug was inserted, but unable to introduce all requested.
     assert "Added bug." in stdout
     assert "Unable to introduce additional bugs of the requested type." in stdout
-
 
 
 def test_no_bugs(tmp_path_factory, test_config):

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -58,8 +58,8 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
     cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
-    assert 'dog_bark.py", line 12' in stderr
-    assert "IndentationError: unexpected indent" in stderr
+
+    assert "AttributeError" in stderr
 
 @pytest.mark.parametrize("num_bugs", [2, 10])
 def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -18,7 +18,7 @@ import pytest
 
 # --- Test functions ---
 
-def test_help(e2e_config):
+def test_help(test_config):
     """Test output of `py-bugger --help`."""
     # Set an explicit column width, so output is consistent across systems.
     env = os.environ.copy()
@@ -28,20 +28,20 @@ def test_help(e2e_config):
     cmd_parts = shlex.split(cmd)
     stdout = subprocess.run(cmd_parts, capture_output=True, env=env).stdout.decode()
 
-    path_help_output = e2e_config.path_reference_files / "help.txt"
+    path_help_output = test_config.path_reference_files / "help.txt"
     assert stdout.replace("\r\n", "\n") == path_help_output.read_text().replace(
         "\r\n", "\n"
     )
 
 
-def test_no_exception_type(tmp_path_factory, e2e_config):
+def test_no_exception_type(tmp_path_factory, test_config):
     """Test that passing no -e arg chooses a random exception type to induce."""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog_bark.py"
+    path_src = test_config.path_sample_scripts / "dog_bark.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -55,21 +55,21 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
 
     assert "AttributeError" in stderr
 
 @pytest.mark.parametrize("num_bugs", [2, 15])
-def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
+def test_no_exception_type_with_narg(tmp_path_factory, test_config, num_bugs):
     """Test that passing no -e arg works with --num-bugs."""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog_bark.py"
+    path_src = test_config.path_sample_scripts / "dog_bark.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -87,7 +87,7 @@ def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
         assert "Unable to introduce additional bugs of the requested type." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
 
@@ -95,7 +95,7 @@ def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
 
 
 @pytest.mark.skip()
-def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
+def test_no_exception_type_first_not_possible(tmp_path_factory, test_config):
     """Test that passing no -e arg induces an exception, even when the first 
     exception type randomly selected is not possible.
     """
@@ -107,7 +107,7 @@ def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
     # The first exception type chosen it will attempt is IndentationError.
     # This sample script has no indented blocks, so py-bugger will have to 
     # find another exception to induce.
-    path_src = e2e_config.path_sample_scripts / "system_info_script.py"
+    path_src = test_config.path_sample_scripts / "system_info_script.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -120,7 +120,7 @@ def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert 'dog_bark.py", line 12' in stderr
@@ -128,15 +128,15 @@ def test_no_exception_type_first_not_possible(tmp_path_factory, e2e_config):
 
 
 
-def test_modulenotfounderror(tmp_path_factory, e2e_config):
+def test_modulenotfounderror(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError"""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_name_picker.name
-    shutil.copyfile(e2e_config.path_name_picker, path_dst)
+    path_dst = tmp_path / test_config.path_name_picker.name
+    shutil.copyfile(test_config.path_name_picker, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -147,7 +147,7 @@ def test_modulenotfounderror(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -155,7 +155,7 @@ def test_modulenotfounderror(tmp_path_factory, e2e_config):
     assert "ModuleNotFoundError: No module named" in stderr
 
 
-def test_default_one_error(tmp_path_factory, e2e_config):
+def test_default_one_error(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError
 
     Test that only one import statement is modified.
@@ -165,8 +165,8 @@ def test_default_one_error(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_system_info.name
-    shutil.copyfile(e2e_config.path_system_info, path_dst)
+    path_dst = tmp_path / test_config.path_system_info.name
+    shutil.copyfile(test_config.path_system_info, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -176,7 +176,7 @@ def test_default_one_error(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -188,7 +188,7 @@ def test_default_one_error(tmp_path_factory, e2e_config):
     assert "import sys" in modified_source or "import os" in modified_source
 
 
-def test_two_bugs(tmp_path_factory, e2e_config):
+def test_two_bugs(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError --num-bugs 2
 
     Test that both import statements are modified.
@@ -197,8 +197,8 @@ def test_two_bugs(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_system_info.name
-    shutil.copyfile(e2e_config.path_system_info, path_dst)
+    path_dst = tmp_path / test_config.path_system_info.name
+    shutil.copyfile(test_config.path_system_info, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --num-bugs 2 --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -209,7 +209,7 @@ def test_two_bugs(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -224,7 +224,7 @@ def test_two_bugs(tmp_path_factory, e2e_config):
     assert "import os" not in lines
 
 
-def test_random_import_affected(tmp_path_factory, e2e_config):
+def test_random_import_affected(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError
 
     Test that a random import statement is modified.
@@ -233,8 +233,8 @@ def test_random_import_affected(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_ten_imports.name
-    shutil.copyfile(e2e_config.path_ten_imports, path_dst)
+    path_dst = tmp_path / test_config.path_ten_imports.name
+    shutil.copyfile(test_config.path_ten_imports, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -245,7 +245,7 @@ def test_random_import_affected(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -269,7 +269,7 @@ def test_random_import_affected(tmp_path_factory, e2e_config):
     assert sum([p in modified_source for p in pkgs]) == 9
 
 
-def test_random_py_file_affected(tmp_path_factory, e2e_config):
+def test_random_py_file_affected(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError
 
     Test that a random .py file is modified.
@@ -278,11 +278,11 @@ def test_random_py_file_affected(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst_ten_imports = tmp_path / e2e_config.path_ten_imports.name
-    shutil.copyfile(e2e_config.path_ten_imports, path_dst_ten_imports)
+    path_dst_ten_imports = tmp_path / test_config.path_ten_imports.name
+    shutil.copyfile(test_config.path_ten_imports, path_dst_ten_imports)
 
-    path_dst_system_info = tmp_path / e2e_config.path_system_info.name
-    shutil.copyfile(e2e_config.path_system_info, path_dst_system_info)
+    path_dst_system_info = tmp_path / test_config.path_system_info.name
+    shutil.copyfile(test_config.path_system_info, path_dst_system_info)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -297,13 +297,13 @@ def test_random_py_file_affected(tmp_path_factory, e2e_config):
     if platform.system() in ["Windows", "Linux"]:
         path_modified = path_dst_ten_imports
         path_unmodified = path_dst_system_info
-        path_unmodified_original = e2e_config.path_system_info
+        path_unmodified_original = test_config.path_system_info
     else:
         path_modified = path_dst_system_info
         path_unmodified = path_dst_ten_imports
-        path_unmodified_original = e2e_config.path_ten_imports
+        path_unmodified_original = test_config.path_ten_imports
     
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_modified.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_modified.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True, text=True).stderr
 
@@ -318,13 +318,13 @@ def test_random_py_file_affected(tmp_path_factory, e2e_config):
 @pytest.mark.parametrize(
     "exception_type", ["IndentationError", "AttributeError", "ModuleNotFoundError"]
 )
-def test_unable_insert_all_bugs(tmp_path_factory, e2e_config, exception_type):
+def test_unable_insert_all_bugs(tmp_path_factory, test_config, exception_type):
     """Test for appropriate message when unable to generate all requested bugs."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog_bark.py"
+    path_src = test_config.path_sample_scripts / "dog_bark.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -340,13 +340,13 @@ def test_unable_insert_all_bugs(tmp_path_factory, e2e_config, exception_type):
 
 
 
-def test_no_bugs(tmp_path_factory, e2e_config):
+def test_no_bugs(tmp_path_factory, test_config):
     """Test for appropriate message when unable to introduce any requested bugs."""
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_zero_imports.name
-    shutil.copyfile(e2e_config.path_zero_imports, path_dst)
+    path_dst = tmp_path / test_config.path_zero_imports.name
+    shutil.copyfile(test_config.path_zero_imports, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -356,13 +356,13 @@ def test_no_bugs(tmp_path_factory, e2e_config):
     assert "Unable to introduce any of the requested bugs." in stdout
 
 
-def test_target_dir_and_file(tmp_path_factory, e2e_config):
+def test_target_dir_and_file(tmp_path_factory, test_config):
     """Test an invalid call including --target-dir and --target-file."""
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_zero_imports.name
-    shutil.copyfile(e2e_config.path_zero_imports, path_dst)
+    path_dst = tmp_path / test_config.path_zero_imports.name
+    shutil.copyfile(test_config.path_zero_imports, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --target-file {path_dst.as_posix()}"
@@ -375,17 +375,17 @@ def test_target_dir_and_file(tmp_path_factory, e2e_config):
     )
 
 
-def test_target_file(tmp_path_factory, e2e_config):
+def test_target_file(tmp_path_factory, test_config):
     """Test for passing --target-file."""
     # Copy two sample scripts to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst_ten_imports = tmp_path / e2e_config.path_ten_imports.name
-    shutil.copyfile(e2e_config.path_ten_imports, path_dst_ten_imports)
+    path_dst_ten_imports = tmp_path / test_config.path_ten_imports.name
+    shutil.copyfile(test_config.path_ten_imports, path_dst_ten_imports)
 
-    path_dst_system_info = tmp_path / e2e_config.path_system_info.name
-    shutil.copyfile(e2e_config.path_system_info, path_dst_system_info)
+    path_dst_system_info = tmp_path / test_config.path_system_info.name
+    shutil.copyfile(test_config.path_system_info, path_dst_system_info)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-file {path_dst_system_info.as_posix()} --ignore-git-status"
@@ -396,7 +396,7 @@ def test_target_file(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise ModuleNotFoundError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst_system_info.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst_system_info.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -404,18 +404,18 @@ def test_target_file(tmp_path_factory, e2e_config):
     assert "ModuleNotFoundError: No module named " in stderr
 
     # Other file should not be changed.
-    assert filecmp.cmp(e2e_config.path_ten_imports, path_dst_ten_imports)
+    assert filecmp.cmp(test_config.path_ten_imports, path_dst_ten_imports)
 
 
-def test_attribute_error(tmp_path_factory, e2e_config):
+def test_attribute_error(tmp_path_factory, test_config):
     """py-bugger --exception-type AttributeError"""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_name_picker.name
-    shutil.copyfile(e2e_config.path_name_picker, path_dst)
+    path_dst = tmp_path / test_config.path_name_picker.name
+    shutil.copyfile(test_config.path_name_picker, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type AttributeError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -427,7 +427,7 @@ def test_attribute_error(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise AttributeError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -436,14 +436,14 @@ def test_attribute_error(tmp_path_factory, e2e_config):
     assert "Did you mean: " in stderr
 
 
-def test_one_node_changed(tmp_path_factory, e2e_config):
+def test_one_node_changed(tmp_path_factory, test_config):
     """Test that only one node in a file is modified for identical nodes."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_dog.name
-    shutil.copyfile(e2e_config.path_dog, path_dst)
+    path_dst = tmp_path / test_config.path_dog.name
+    shutil.copyfile(test_config.path_dog, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type AttributeError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -454,7 +454,7 @@ def test_one_node_changed(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise AttributeError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -468,14 +468,14 @@ def test_one_node_changed(tmp_path_factory, e2e_config):
     assert "self.nam" in modified_source
 
 
-def test_random_node_changed(tmp_path_factory, e2e_config):
+def test_random_node_changed(tmp_path_factory, test_config):
     """Test that a random node in a file is modified if it has numerous identical nodes."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_identical_attributes.name
-    shutil.copyfile(e2e_config.path_identical_attributes, path_dst)
+    path_dst = tmp_path / test_config.path_identical_attributes.name
+    shutil.copyfile(test_config.path_identical_attributes, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type AttributeError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -486,7 +486,7 @@ def test_random_node_changed(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise AttributeError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -499,7 +499,7 @@ def test_random_node_changed(tmp_path_factory, e2e_config):
     assert modified_source.count("random.choice(") == 19
 
 
-def test_indentation_error_simple(tmp_path_factory, e2e_config):
+def test_indentation_error_simple(tmp_path_factory, test_config):
     """py-bugger --exception-type IndentationError
 
     Run against a file with a single indented block.
@@ -509,8 +509,8 @@ def test_indentation_error_simple(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_simple_indent.name
-    shutil.copyfile(e2e_config.path_simple_indent, path_dst)
+    path_dst = tmp_path / test_config.path_simple_indent.name
+    shutil.copyfile(test_config.path_simple_indent, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type IndentationError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -522,7 +522,7 @@ def test_indentation_error_simple(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
@@ -534,7 +534,7 @@ def test_indentation_error_simple(tmp_path_factory, e2e_config):
 # in the function, induce an error that indents the for line, not the
 # def line, and assert not TabError.
 @pytest.mark.skip()
-def test_indentation_error_simple_tab(tmp_path_factory, e2e_config):
+def test_indentation_error_simple_tab(tmp_path_factory, test_config):
     """py-bugger --exception-type IndentationError
 
     Run against a file with a single indented block, using a tab delimiter.
@@ -543,7 +543,7 @@ def test_indentation_error_simple_tab(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "simple_indent_tab.py"
+    path_src = test_config.path_sample_scripts / "simple_indent_tab.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -557,14 +557,14 @@ def test_indentation_error_simple_tab(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
     assert 'simple_indent_tab.py", line 1' in stderr
 
 
-def test_indentation_error_complex(tmp_path_factory, e2e_config):
+def test_indentation_error_complex(tmp_path_factory, test_config):
     """py-bugger --exception-type IndentationError
 
     Run against a file with multiple indented blocks of different kinds.
@@ -573,8 +573,8 @@ def test_indentation_error_complex(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_many_dogs.name
-    shutil.copyfile(e2e_config.path_many_dogs, path_dst)
+    path_dst = tmp_path / test_config.path_many_dogs.name
+    shutil.copyfile(test_config.path_many_dogs, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type IndentationError --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -586,14 +586,14 @@ def test_indentation_error_complex(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
     assert 'many_dogs.py", line 1' in stderr
 
 
-def test_all_indentation_blocks(tmp_path_factory, e2e_config):
+def test_all_indentation_blocks(tmp_path_factory, test_config):
     """Test that all kinds of indented blocks can be modified.
 
     Note: There are a couple blocks that aren't currently in all_indentation_blocks.py
@@ -603,8 +603,8 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_all_indentation_blocks.name
-    shutil.copyfile(e2e_config.path_all_indentation_blocks, path_dst)
+    path_dst = tmp_path / test_config.path_all_indentation_blocks.name
+    shutil.copyfile(test_config.path_all_indentation_blocks, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type IndentationError --num-bugs 8 --target-dir {tmp_path.as_posix()} --ignore-git-status"
@@ -616,14 +616,14 @@ def test_all_indentation_blocks(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "IndentationError: unexpected indent" in stderr
     assert 'all_indentation_blocks.py", line 1' in stderr
 
 
-def test_indentation_else_block(tmp_path_factory, e2e_config):
+def test_indentation_else_block(tmp_path_factory, test_config):
     """Test that an indendented else block does not result in a SyntaxError.
 
     If the else block is moved to its own indentation level, -> IndentationError.
@@ -639,7 +639,7 @@ def test_indentation_else_block(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "else_block.py"
+    path_src = test_config.path_sample_scripts / "else_block.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -653,7 +653,7 @@ def test_indentation_else_block(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise IndentationError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "SyntaxError: invalid syntax" not in stderr

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -86,12 +86,15 @@ def test_no_exception_type_with_narg(tmp_path_factory, test_config, num_bugs):
         assert "Inserted " in stdout
         assert "Unable to introduce additional bugs of the requested type." in stdout
 
-    # Run file, should raise IndentationError.
+    # Run file, should raise an error.
     cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
 
-    assert "AttributeError" in stderr
+    if num_bugs == 2:
+        assert "AttributeError" in stderr
+    else:
+        assert "IndentationError" in stderr
 
 
 @pytest.mark.skip()

--- a/tests/e2e_tests/test_basic_behavior.py
+++ b/tests/e2e_tests/test_basic_behavior.py
@@ -61,7 +61,7 @@ def test_no_exception_type(tmp_path_factory, e2e_config):
 
     assert "AttributeError" in stderr
 
-@pytest.mark.parametrize("num_bugs", [2, 10])
+@pytest.mark.parametrize("num_bugs", [2, 15])
 def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
     """Test that passing no -e arg works with --num-bugs."""
 
@@ -82,7 +82,7 @@ def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
 
     if num_bugs == 2:
         assert "All requested bugs inserted." in stdout
-    elif num_bugs == 10:
+    elif num_bugs == 15:
         assert "Inserted " in stdout
         assert "Unable to introduce additional bugs of the requested type." in stdout
 
@@ -91,8 +91,7 @@ def test_no_exception_type_with_narg(tmp_path_factory, e2e_config, num_bugs):
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
 
-    assert 'dog_bark.py", line 12' in stderr
-    assert "IndentationError: unexpected indent" in stderr
+    assert "AttributeError" in stderr
 
 
 @pytest.mark.skip()

--- a/tests/e2e_tests/test_cli_flags.py
+++ b/tests/e2e_tests/test_cli_flags.py
@@ -12,15 +12,15 @@ import os
 import sys
 
 
-def test_verbose_flag_true(tmp_path_factory, e2e_config):
+def test_verbose_flag_true(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError --verbose"""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_name_picker.name
-    shutil.copyfile(e2e_config.path_name_picker, path_dst)
+    path_dst = tmp_path / test_config.path_name_picker.name
+    shutil.copyfile(test_config.path_name_picker, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --verbose --ignore-git-status"
@@ -31,15 +31,15 @@ def test_verbose_flag_true(tmp_path_factory, e2e_config):
     assert "name_picker.py" in stdout
 
 
-def test_verbose_flag_false(tmp_path_factory, e2e_config):
+def test_verbose_flag_false(tmp_path_factory, test_config):
     """py-bugger --exception-type ModuleNotFoundError"""
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_name_picker.name
-    shutil.copyfile(e2e_config.path_name_picker, path_dst)
+    path_dst = tmp_path / test_config.path_name_picker.name
+    shutil.copyfile(test_config.path_name_picker, path_dst)
 
     # Run py-bugger against directory.
     cmd = f"py-bugger --exception-type ModuleNotFoundError --target-dir {tmp_path.as_posix()} --ignore-git-status"

--- a/tests/e2e_tests/test_git_status_checks.py
+++ b/tests/e2e_tests/test_git_status_checks.py
@@ -18,13 +18,13 @@ from py_bugger.cli import cli_messages
 from py_bugger.cli.config import PBConfig
 
 
-def test_git_not_available(tmp_path_factory, e2e_config, on_windows):
+def test_git_not_available(tmp_path_factory, test_config, on_windows):
     """Check appropriate message shown when Git not available."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -45,13 +45,13 @@ def test_git_not_available(tmp_path_factory, e2e_config, on_windows):
     assert msg_expected in stdout
 
 
-def test_git_not_used(tmp_path_factory, e2e_config):
+def test_git_not_used(tmp_path_factory, test_config):
     """Check appropriate message shown when Git not being used."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -71,13 +71,13 @@ def test_git_not_used(tmp_path_factory, e2e_config):
     assert msg_expected in stdout
 
 
-def test_unclean_git_status(tmp_path_factory, e2e_config):
+def test_unclean_git_status(tmp_path_factory, test_config):
     """Check appropriate message shown when Git status is not clean."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -100,7 +100,7 @@ def test_unclean_git_status(tmp_path_factory, e2e_config):
     assert msg_expected in stdout
 
 
-def test_clean_git_status(tmp_path_factory, e2e_config):
+def test_clean_git_status(tmp_path_factory, test_config):
     """Run py-bugger against a tiny repo with a clean status, without passing
     --ignore-git-status.
     """
@@ -108,7 +108,7 @@ def test_clean_git_status(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -138,7 +138,7 @@ def test_clean_git_status(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise AttributeError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr
@@ -147,7 +147,7 @@ def test_clean_git_status(tmp_path_factory, e2e_config):
     assert "Did you mean: " in stderr
 
 
-def test_ignore_git_status(tmp_path_factory, e2e_config):
+def test_ignore_git_status(tmp_path_factory, test_config):
     """Test that py-bugger runs when --ignore-git-status is passed.
 
     This is the test for Git not being used, with a different assertion.
@@ -156,7 +156,7 @@ def test_ignore_git_status(tmp_path_factory, e2e_config):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -170,7 +170,7 @@ def test_ignore_git_status(tmp_path_factory, e2e_config):
     assert "All requested bugs inserted." in stdout
 
     # Run file, should raise AttributeError.
-    cmd = f"{e2e_config.python_cmd.as_posix()} {path_dst.as_posix()}"
+    cmd = f"{test_config.python_cmd.as_posix()} {path_dst.as_posix()}"
     cmd_parts = shlex.split(cmd)
     stderr = subprocess.run(cmd_parts, capture_output=True).stderr.decode()
     assert "Traceback (most recent call last)" in stderr

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -78,7 +78,7 @@ def test_preserve_file_ending_no_trailing_newline(
 
     # Check that last line is not blank.
     lines = path_dst.read_text().splitlines(keepends=True)
-    
+
     assert lines[-1] == "dog.say_hi()"
 
 

--- a/tests/e2e_tests/test_non_bugmaking_behavior.py
+++ b/tests/e2e_tests/test_non_bugmaking_behavior.py
@@ -25,7 +25,7 @@ from py_bugger.cli import cli_messages
     "exception_type", ["IndentationError", "AttributeError", "ModuleNotFoundError"]
 )
 def test_preserve_file_ending_trailing_newline(
-    tmp_path_factory, e2e_config, exception_type
+    tmp_path_factory, test_config, exception_type
 ):
     """Test that trailing newlines are preserved when present."""
 
@@ -33,8 +33,8 @@ def test_preserve_file_ending_trailing_newline(
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_dst = tmp_path / e2e_config.path_dog_bark.name
-    shutil.copyfile(e2e_config.path_dog_bark, path_dst)
+    path_dst = tmp_path / test_config.path_dog_bark.name
+    shutil.copyfile(test_config.path_dog_bark, path_dst)
 
     # Run py-bugger against file.
     cmd = f"py-bugger --exception-type {exception_type} --target-file {path_dst.as_posix()} --ignore-git-status"
@@ -55,7 +55,7 @@ def test_preserve_file_ending_trailing_newline(
     "exception_type", ["IndentationError", "AttributeError", "ModuleNotFoundError"]
 )
 def test_preserve_file_ending_no_trailing_newline(
-    tmp_path_factory, e2e_config, exception_type
+    tmp_path_factory, test_config, exception_type
 ):
     """Test that trailing newlines are not introduced when not originally present."""
 
@@ -63,7 +63,7 @@ def test_preserve_file_ending_no_trailing_newline(
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog_bark_no_trailing_newline.py"
+    path_src = test_config.path_sample_scripts / "dog_bark_no_trailing_newline.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -86,7 +86,7 @@ def test_preserve_file_ending_no_trailing_newline(
     "exception_type", ["IndentationError", "AttributeError", "ModuleNotFoundError"]
 )
 def test_preserve_file_ending_two_trailing_newline(
-    tmp_path_factory, e2e_config, exception_type
+    tmp_path_factory, test_config, exception_type
 ):
     """Test that two trailing newlines are preserved when present."""
 
@@ -94,7 +94,7 @@ def test_preserve_file_ending_two_trailing_newline(
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog_bark_two_trailing_newlines.py"
+    path_src = test_config.path_sample_scripts / "dog_bark_two_trailing_newlines.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -118,13 +118,13 @@ def test_preserve_file_ending_two_trailing_newline(
 @pytest.mark.parametrize(
     "exception_type", ["IndentationError", "AttributeError", "ModuleNotFoundError"]
 )
-def test_blank_file_behavior(tmp_path_factory, e2e_config, exception_type):
+def test_blank_file_behavior(tmp_path_factory, test_config, exception_type):
     """Make sure py-bugger handles a blank file correctly."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "blank_file.py"
+    path_src = test_config.path_sample_scripts / "blank_file.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -145,13 +145,13 @@ def test_blank_file_behavior(tmp_path_factory, e2e_config, exception_type):
 ### --- Tests for invalid --target-dir calls ---
 
 
-def test_file_passed_to_targetdir(tmp_path_factory, e2e_config):
+def test_file_passed_to_targetdir(tmp_path_factory, test_config):
     """Make sure passing a file to --target-dir fails appropriately."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "dog.py"
+    path_src = test_config.path_sample_scripts / "dog.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -278,13 +278,13 @@ def test_targetfile_exists_not_file():
     assert msg_expected in stdout
 
 
-def test_targetfile_py_file(tmp_path_factory, e2e_config):
+def test_targetfile_py_file(tmp_path_factory, test_config):
     """Test for appropriate message when passed a non-.py file."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = e2e_config.path_sample_scripts / "hello.txt"
+    path_src = test_config.path_sample_scripts / "hello.txt"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 

--- a/tests/e2e_tests/test_project_setup.py
+++ b/tests/e2e_tests/test_project_setup.py
@@ -1,12 +1,12 @@
 """Test aspects of project setup that might interfere with CI and the release process."""
 
 
-def test_editable_requirement(e2e_config):
+def test_editable_requirement(test_config):
     """Make sure there's no editable entry for py-bugger in requirements.txt.
 
     This entry gets inserted when running pip freeze, from an editable install.
     """
-    path_req_txt = e2e_config.path_root / "requirements.txt"
+    path_req_txt = test_config.path_root / "requirements.txt"
 
     contents = path_req_txt.read_text()
     assert "-e file:" not in contents

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -11,8 +11,17 @@ from py_bugger.cli.config import pb_config
 
 
 @pytest.fixture(autouse=True, scope="function")
-def reset_pbconfig():
-    """Reset the pb_config object for each test."""
-    # Cleanup.
-    pb_config.target_dir = None
+def reset_state():
+    """Reset the shared state objects for each test."""
+
+    # # Reset pb_config.
+    # pb_config.exception_type = ""
+    pb_config.target_dir = ""
+    # pb_config.target_file = ""
+    # pb_config.num_bugs = 1
+    # pb_config.ignore_git_status = False
+    # pb_config.verbose = True
+
+    # Reset list of modifications.
     modifications.clear()
+

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -3,3 +3,16 @@
 Any test that's more than a unit test, but doesn't require running py-bugger against
 actual code should probably be an integration test.
 """
+
+import pytest
+
+from py_bugger.utils.modification import modifications
+from py_bugger.cli.config import pb_config
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_pbconfig():
+    """Reset the pb_config object for each test."""
+    # Cleanup.
+    pb_config.target_dir = None
+    modifications.clear()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -14,13 +14,13 @@ from py_bugger.cli.config import pb_config
 def reset_state():
     """Reset the shared state objects for each test."""
 
-    # # Reset pb_config.
-    # pb_config.exception_type = ""
+    # Reset pb_config.
+    pb_config.exception_type = ""
     pb_config.target_dir = ""
-    # pb_config.target_file = ""
-    # pb_config.num_bugs = 1
-    # pb_config.ignore_git_status = False
-    # pb_config.verbose = True
+    pb_config.target_file = ""
+    pb_config.num_bugs = 1
+    pb_config.ignore_git_status = False
+    pb_config.verbose = True
 
     # Reset list of modifications.
     modifications.clear()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -25,3 +25,9 @@ def reset_state():
     # Reset list of modifications.
     modifications.clear()
 
+    # Customize some state. For some tests, you may need to override
+    # these customizations in specific test functions.
+
+    # For most integration tests, we're targeting a sample file or directory
+    # that has not been set up as a Git repo.
+    pb_config.ignore_git_status = True

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -15,7 +15,12 @@ from py_bugger.cli import cli_messages
 
 
 @pytest.mark.parametrize(
-    "actual_expected", [("IndentationErrorr", "IndentationError"), ("AttributeErrorr", "AttributeError"), ("ModuleNotFoundErrorr", "ModuleNotFoundError")]
+    "actual_expected",
+    [
+        ("IndentationErrorr", "IndentationError"),
+        ("AttributeErrorr", "AttributeError"),
+        ("ModuleNotFoundErrorr", "ModuleNotFoundError"),
+    ],
 )
 def test_exception_type_typo(actual_expected):
     """Test appropriate handling of a typo in the exception type."""
@@ -29,6 +34,7 @@ def test_exception_type_typo(actual_expected):
 
     msg_expected = cli_messages.msg_apparent_typo(exception_type, correction)
     assert msg_expected in stdout
+
 
 def test_exception_type_unsupported():
     """Test appropriate handling of an unsupported exception type."""

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -12,7 +12,7 @@ from py_bugger.cli import cli_utils
 from py_bugger.utils.modification import modifications
 
 
-def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
+def test_modifications_modulenotfounderror(tmp_path_factory, test_config):
     """Tests modifications after creating a ModuleNotFoundError."""
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -1,0 +1,40 @@
+"""Test the modifications object."""
+
+from pathlib import Path
+import shutil
+
+from py_bugger.cli import cli_utils
+
+
+
+def test_modifications_modulenotfounderror(tmp_path_factory):
+    """Tests modifications after creating a ModuleNotFoundError."""
+    path_root = Path(__file__).parents[2]
+    path_tests = path_root / "tests"
+    path_reference_files = path_tests / "e2e_tests" / "reference_files"
+    path_sample_code = path_tests / "sample_code"
+    path_sample_scripts = path_sample_code / "sample_scripts"
+
+    from py_bugger.cli.config import pb_config
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = path_sample_scripts / "name_picker.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Make modifications against this directory.
+    pb_config.exception_type = "ModuleNotFoundError"
+    pb_config.target_file = path_dst
+    pb_config.ignore_git_status = True
+
+    cli_utils.validate_config()
+
+    from py_bugger import py_bugger
+    py_bugger.main()
+
+    from py_bugger.utils.modification import modifications
+    assert len(modifications) == 1
+    

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import shutil
 import os
 
+from py_bugger.cli.config import pb_config
+from py_bugger.cli import cli_utils
+
 
 def test_modifications_modulenotfounderror(tmp_path_factory):
     """Tests modifications after creating a ModuleNotFoundError."""
@@ -12,9 +15,6 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     path_reference_files = path_tests / "e2e_tests" / "reference_files"
     path_sample_code = path_tests / "sample_code"
     path_sample_scripts = path_sample_code / "sample_scripts"
-
-    from py_bugger.cli.config import pb_config
-    from py_bugger.cli import cli_utils
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
@@ -50,9 +50,6 @@ def test_4_random_bugs(tmp_path_factory, test_config):
 
     Look for modifications that match bugs_requested.
     """
-    from py_bugger.cli.config import pb_config
-    from py_bugger.cli import cli_utils
-
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -40,3 +40,47 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     # Cleanup.
     pb_config.target_dir = None
     modifications.clear()
+
+def test_5_random_bugs(tmp_path_factory):
+    """Test equivalent of `py-bugger -n 5`.
+
+    Look for modifications that match bugs_requested.
+    """
+    path_root = Path(__file__).parents[2]
+    path_tests = path_root / "tests"
+    path_reference_files = path_tests / "e2e_tests" / "reference_files"
+    path_sample_code = path_tests / "sample_code"
+    path_sample_scripts = path_sample_code / "sample_scripts"
+
+    from py_bugger.cli.config import pb_config
+    from py_bugger.cli import cli_utils
+
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = path_sample_scripts / "dog_bark.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Make modifications against this directory.
+    pb_config.exception_type = ""
+    pb_config.target_file = path_dst
+    pb_config.ignore_git_status = True
+    pb_config.num_bugs = 5
+
+    cli_utils.validate_config()
+
+    from py_bugger import py_bugger
+    from py_bugger.utils.modification import modifications
+
+    requested_bugs = py_bugger.main()
+
+    assert len(modifications) == len(requested_bugs)
+
+    exceptions_induced_str = [m.exception_induced.__name__ for m in modifications]
+    assert sorted(exceptions_induced_str) == sorted(requested_bugs)
+
+    # Cleanup.
+    pb_config.target_dir = None
+    modifications.clear()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -35,7 +35,7 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
 
     from py_bugger.utils.modification import modifications
     assert len(modifications) == 1
-    assert modifications[0].exception_induced == "ModuleNotFoundError"
+    assert modifications[0].exception_induced == ModuleNotFoundError
 
     # Cleanup.
     pb_config.target_dir = None

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -56,12 +56,11 @@ def test_4_random_bugs(tmp_path_factory, test_config):
 
     cli_utils.validate_config()
 
-    assert os.environ["PY_BUGGER_RANDOM_SEED"] == "10"
-    assert not pb_config.exception_type
     requested_bugs = py_bugger.main()
-    assert requested_bugs == ['AttributeError', 'AttributeError', 'AttributeError', 'ModuleNotFoundError']
 
+    # Make sure one modification was made for each requested bug.
     assert len(modifications) == len(requested_bugs)
 
+    # Make sure the correct kinds of exceptions were induced.
     exceptions_induced_str = [m.exception_induced.__name__ for m in modifications]
     assert sorted(exceptions_induced_str) == sorted(requested_bugs)

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -11,14 +11,6 @@ from py_bugger.cli import cli_utils
 from py_bugger.utils.modification import modifications
 
 
-@pytest.fixture(autouse=True, scope="function")
-def reset_pbconfig():
-    """Reset the pb_config object for each test."""
-    # Cleanup.
-    pb_config.target_dir = None
-    modifications.clear()
-
-
 def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
     """Tests modifications after creating a ModuleNotFoundError."""
     # Copy sample code to tmp dir.

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -61,3 +61,38 @@ def test_7_random_bugs(tmp_path_factory, test_config):
     # Make sure the correct kinds of exceptions were induced.
     exceptions_induced_str = [m.exception_induced.__name__ for m in modifications]
     assert sorted(exceptions_induced_str) == sorted(requested_bugs)
+
+
+def test_8_random_bugs(tmp_path_factory, test_config):
+    """Test equivalent of `py-bugger -n 8`.
+
+    Look for modifications that match bugs_requested.
+    Look for message that it can't add more bugs.
+    """
+    # Copy sample code to tmp dir.
+    tmp_path = tmp_path_factory.mktemp("sample_code")
+    print(f"\nCopying code to: {tmp_path.as_posix()}")
+
+    path_src = test_config.path_sample_scripts / "dog_bark.py"
+    path_dst = tmp_path / path_src.name
+    shutil.copyfile(path_src, path_dst)
+
+    # Make modifications against this directory.
+    # With the current random seed, 8 seems to be the smallest number of bugs
+    # where it can't finish adding bugs.
+    pb_config.target_file = path_dst
+    pb_config.num_bugs = 8
+    cli_utils.validate_config()
+
+    requested_bugs = py_bugger.main()
+
+    # Make sure one requested bug was unable to be generated.
+    assert len(modifications) == len(requested_bugs) - 1
+
+    # Make sure all requested bugs except one are in modifications.
+    exceptions_induced_str = [m.exception_induced.__name__ for m in modifications]
+    while exceptions_induced_str:
+        exception_induced = exceptions_induced_str.pop()
+        requested_bugs.remove(exception_induced)
+
+    assert len(requested_bugs) == 1

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -33,8 +33,8 @@ def test_modifications_modulenotfounderror(tmp_path_factory, test_config):
     assert modifications[0].exception_induced == ModuleNotFoundError
 
 
-def test_4_random_bugs(tmp_path_factory, test_config):
-    """Test equivalent of `py-bugger -n 4`.
+def test_7_random_bugs(tmp_path_factory, test_config):
+    """Test equivalent of `py-bugger -n 7`.
 
     Look for modifications that match bugs_requested.
     """
@@ -47,8 +47,10 @@ def test_4_random_bugs(tmp_path_factory, test_config):
     shutil.copyfile(path_src, path_dst)
 
     # Make modifications against this directory.
+    # With the current random seed, 7 seems to be the max number of bugs before
+    # it can't add more.
     pb_config.target_file = path_dst
-    pb_config.num_bugs = 4
+    pb_config.num_bugs = 7
     cli_utils.validate_config()
 
     requested_bugs = py_bugger.main()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -56,7 +56,10 @@ def test_4_random_bugs(tmp_path_factory, test_config):
 
     cli_utils.validate_config()
 
+    assert os.environ["PY_BUGGER_RANDOM_SEED"] == "10"
+    assert not pb_config.exception_type
     requested_bugs = py_bugger.main()
+    assert requested_bugs == ['AttributeError', 'AttributeError', 'AttributeError', 'ModuleNotFoundError']
 
     assert len(modifications) == len(requested_bugs)
 

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -32,15 +32,18 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     cli_utils.validate_config()
 
     from py_bugger import py_bugger
+
     py_bugger.main()
 
     from py_bugger.utils.modification import modifications
+
     assert len(modifications) == 1
     assert modifications[0].exception_induced == ModuleNotFoundError
 
     # Cleanup.
     pb_config.target_dir = None
     modifications.clear()
+
 
 def test_4_random_bugs(tmp_path_factory, test_config):
     """Test equivalent of `py-bugger -n 4`.

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -3,9 +3,6 @@
 from pathlib import Path
 import shutil
 
-from py_bugger.cli import cli_utils
-
-
 
 def test_modifications_modulenotfounderror(tmp_path_factory):
     """Tests modifications after creating a ModuleNotFoundError."""
@@ -16,6 +13,7 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     path_sample_scripts = path_sample_code / "sample_scripts"
 
     from py_bugger.cli.config import pb_config
+    from py_bugger.cli import cli_utils
 
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
@@ -37,4 +35,7 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
 
     from py_bugger.utils.modification import modifications
     assert len(modifications) == 1
-    
+
+    # Cleanup.
+    pb_config.target_dir = None
+    modifications.clear()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -25,7 +25,6 @@ def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
     # Make modifications against this directory.
     pb_config.exception_type = "ModuleNotFoundError"
     pb_config.target_file = path_dst
-
     cli_utils.validate_config()
 
     py_bugger.main()
@@ -50,7 +49,6 @@ def test_4_random_bugs(tmp_path_factory, test_config):
     # Make modifications against this directory.
     pb_config.target_file = path_dst
     pb_config.num_bugs = 4
-
     cli_utils.validate_config()
 
     requested_bugs = py_bugger.main()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -42,18 +42,11 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     pb_config.target_dir = None
     modifications.clear()
 
-def test_5_random_bugs(tmp_path_factory):
+def test_5_random_bugs(tmp_path_factory, test_config):
     """Test equivalent of `py-bugger -n 5`.
 
     Look for modifications that match bugs_requested.
     """
-    assert os.environ["PY_BUGGER_RANDOM_SEED"] == "10"
-    path_root = Path(__file__).parents[2]
-    path_tests = path_root / "tests"
-    path_reference_files = path_tests / "e2e_tests" / "reference_files"
-    path_sample_code = path_tests / "sample_code"
-    path_sample_scripts = path_sample_code / "sample_scripts"
-
     from py_bugger.cli.config import pb_config
     from py_bugger.cli import cli_utils
 
@@ -61,7 +54,7 @@ def test_5_random_bugs(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = path_sample_scripts / "dog_bark.py"
+    path_src = test_config.path_sample_scripts / "dog_bark.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 
@@ -77,6 +70,7 @@ def test_5_random_bugs(tmp_path_factory):
     from py_bugger.utils.modification import modifications
 
     requested_bugs = py_bugger.main()
+    breakpoint()
 
     assert len(modifications) == len(requested_bugs)
 

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import shutil
+import os
 
 
 def test_modifications_modulenotfounderror(tmp_path_factory):
@@ -46,6 +47,7 @@ def test_5_random_bugs(tmp_path_factory):
 
     Look for modifications that match bugs_requested.
     """
+    assert os.environ["PY_BUGGER_RANDOM_SEED"] == "10"
     path_root = Path(__file__).parents[2]
     path_tests = path_root / "tests"
     path_reference_files = path_tests / "e2e_tests" / "reference_files"

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -8,19 +8,13 @@ from py_bugger.cli.config import pb_config
 from py_bugger.cli import cli_utils
 
 
-def test_modifications_modulenotfounderror(tmp_path_factory):
+def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
     """Tests modifications after creating a ModuleNotFoundError."""
-    path_root = Path(__file__).parents[2]
-    path_tests = path_root / "tests"
-    path_reference_files = path_tests / "e2e_tests" / "reference_files"
-    path_sample_code = path_tests / "sample_code"
-    path_sample_scripts = path_sample_code / "sample_scripts"
-
     # Copy sample code to tmp dir.
     tmp_path = tmp_path_factory.mktemp("sample_code")
     print(f"\nCopying code to: {tmp_path.as_posix()}")
 
-    path_src = path_sample_scripts / "name_picker.py"
+    path_src = test_config.path_sample_scripts / "name_picker.py"
     path_dst = tmp_path / path_src.name
     shutil.copyfile(path_src, path_dst)
 

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 
+from py_bugger import py_bugger
 from py_bugger.cli.config import pb_config
 from py_bugger.cli import cli_utils
 from py_bugger.utils.modification import modifications
@@ -27,8 +28,6 @@ def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
     pb_config.ignore_git_status = True
 
     cli_utils.validate_config()
-
-    from py_bugger import py_bugger
 
     py_bugger.main()
 
@@ -56,8 +55,6 @@ def test_4_random_bugs(tmp_path_factory, test_config):
     pb_config.num_bugs = 4
 
     cli_utils.validate_config()
-
-    from py_bugger import py_bugger
 
     requested_bugs = py_bugger.main()
 

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -42,8 +42,8 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
     pb_config.target_dir = None
     modifications.clear()
 
-def test_5_random_bugs(tmp_path_factory, test_config):
-    """Test equivalent of `py-bugger -n 5`.
+def test_4_random_bugs(tmp_path_factory, test_config):
+    """Test equivalent of `py-bugger -n 4`.
 
     Look for modifications that match bugs_requested.
     """
@@ -62,7 +62,7 @@ def test_5_random_bugs(tmp_path_factory, test_config):
     pb_config.exception_type = ""
     pb_config.target_file = path_dst
     pb_config.ignore_git_status = True
-    pb_config.num_bugs = 5
+    pb_config.num_bugs = 4
 
     cli_utils.validate_config()
 
@@ -70,7 +70,6 @@ def test_5_random_bugs(tmp_path_factory, test_config):
     from py_bugger.utils.modification import modifications
 
     requested_bugs = py_bugger.main()
-    breakpoint()
 
     assert len(modifications) == len(requested_bugs)
 

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -4,8 +4,19 @@ from pathlib import Path
 import shutil
 import os
 
+import pytest
+
 from py_bugger.cli.config import pb_config
 from py_bugger.cli import cli_utils
+from py_bugger.utils.modification import modifications
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_pbconfig():
+    """Reset the pb_config object for each test."""
+    # Cleanup.
+    pb_config.target_dir = None
+    modifications.clear()
 
 
 def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
@@ -29,14 +40,8 @@ def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
 
     py_bugger.main()
 
-    from py_bugger.utils.modification import modifications
-
     assert len(modifications) == 1
     assert modifications[0].exception_induced == ModuleNotFoundError
-
-    # Cleanup.
-    pb_config.target_dir = None
-    modifications.clear()
 
 
 def test_4_random_bugs(tmp_path_factory, test_config):
@@ -61,7 +66,6 @@ def test_4_random_bugs(tmp_path_factory, test_config):
     cli_utils.validate_config()
 
     from py_bugger import py_bugger
-    from py_bugger.utils.modification import modifications
 
     requested_bugs = py_bugger.main()
 
@@ -69,7 +73,3 @@ def test_4_random_bugs(tmp_path_factory, test_config):
 
     exceptions_induced_str = [m.exception_induced.__name__ for m in modifications]
     assert sorted(exceptions_induced_str) == sorted(requested_bugs)
-
-    # Cleanup.
-    pb_config.target_dir = None
-    modifications.clear()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -25,7 +25,6 @@ def test_modifications_modulenotfounderror(tmp_path_factory,test_config):
     # Make modifications against this directory.
     pb_config.exception_type = "ModuleNotFoundError"
     pb_config.target_file = path_dst
-    pb_config.ignore_git_status = True
 
     cli_utils.validate_config()
 
@@ -49,9 +48,7 @@ def test_4_random_bugs(tmp_path_factory, test_config):
     shutil.copyfile(path_src, path_dst)
 
     # Make modifications against this directory.
-    pb_config.exception_type = ""
     pb_config.target_file = path_dst
-    pb_config.ignore_git_status = True
     pb_config.num_bugs = 4
 
     cli_utils.validate_config()

--- a/tests/integration_tests/test_modifications.py
+++ b/tests/integration_tests/test_modifications.py
@@ -35,6 +35,7 @@ def test_modifications_modulenotfounderror(tmp_path_factory):
 
     from py_bugger.utils.modification import modifications
     assert len(modifications) == 1
+    assert modifications[0].exception_induced == "ModuleNotFoundError"
 
     # Cleanup.
     pb_config.target_dir = None


### PR DESCRIPTION
Avoids writing syntax-related bugs before parsing nodes, which requires valid syntax. Also includes integration tests, which should start to take the place of many slower e2e tests.